### PR TITLE
feat(NUM-551): Adds Icon Preview to playground, changes pg class names

### DIFF
--- a/src/playground/pg_buttons/pg_buttons.component.sandbox.ts
+++ b/src/playground/pg_buttons/pg_buttons.component.sandbox.ts
@@ -1,6 +1,6 @@
 import { sandboxOf } from 'angular-playground'
-import { ButtonsComponent } from './pg_buttons.component'
+import { PgButtonsComponent } from './pg_buttons.component'
 
-export default sandboxOf(ButtonsComponent).add('Buttons', {
+export default sandboxOf(PgButtonsComponent).add('Buttons', {
   template: `<div class="mat-drawer-container"><num-pg-buttons></num-pg-buttons></div>`,
 })

--- a/src/playground/pg_buttons/pg_buttons.component.ts
+++ b/src/playground/pg_buttons/pg_buttons.component.ts
@@ -5,6 +5,6 @@ import { Component } from '@angular/core'
   templateUrl: './pg_buttons.component.html',
   styleUrls: ['./pg_buttons.component.scss'],
 })
-export class ButtonsComponent {
+export class PgButtonsComponent {
   constructor() {}
 }

--- a/src/playground/pg_icons/pg_icons.component.html
+++ b/src/playground/pg_icons/pg_icons.component.html
@@ -1,0 +1,14 @@
+<main>
+  <h1>Icons</h1>
+  <div class="icon-list" fxLayout="row wrap" fxLayout.lt-sm="column" fxLayoutAlign="flex-start">
+    <section
+      *ngFor="let icon of icons"
+      fxFlex="0 1 calc(33.3% - 32px)"
+      fxFlex.lt-md="0 1 calc(50% - 32px)"
+      fxFlex.lt-sm="100%"
+    >
+      <span class="mat-body-strong">{{ icon }}</span>
+      <fa-icon class="num-fc--a" [icon]="icon" size="lg" [fixedWidth]="true"></fa-icon>
+    </section>
+  </div>
+</main>

--- a/src/playground/pg_icons/pg_icons.component.sandbox.ts
+++ b/src/playground/pg_icons/pg_icons.component.sandbox.ts
@@ -1,0 +1,6 @@
+import { sandboxOf } from 'angular-playground'
+import { PgIconsComponent } from './pg_icons.component'
+
+export default sandboxOf(PgIconsComponent).add('Icons', {
+  template: `<div class="mat-drawer-container"><num-pg-icons></num-pg-icons></div>`,
+})

--- a/src/playground/pg_icons/pg_icons.component.scss
+++ b/src/playground/pg_icons/pg_icons.component.scss
@@ -1,0 +1,21 @@
+main {
+  width: 100vw;
+  min-height: 100vh;
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+}
+
+.icon-list {
+  margin-right: -32px;
+}
+
+section {
+  display: flex;
+  justify-content: space-between;
+  width: 95vw;
+  padding: 12px;
+  border: 1px solid grey;
+  margin: 0 32px 8px 0;
+}

--- a/src/playground/pg_icons/pg_icons.component.ts
+++ b/src/playground/pg_icons/pg_icons.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core'
+import { FONT_AWESOME_ICONS } from 'src/app/layout/font-awesome-icons'
+
+@Component({
+  selector: 'num-pg-icons',
+  templateUrl: './pg_icons.component.html',
+  styleUrls: ['./pg_icons.component.scss'],
+})
+export class PgIconsComponent {
+  icons = FONT_AWESOME_ICONS.map((icon) => icon.iconName)
+  constructor() {}
+}

--- a/src/playground/pg_typography/pg_typography.component.sandbox.ts
+++ b/src/playground/pg_typography/pg_typography.component.sandbox.ts
@@ -1,6 +1,6 @@
 import { sandboxOf } from 'angular-playground'
-import { TypographyComponent } from './pg_typography.component'
+import { PgTypographyComponent } from './pg_typography.component'
 
-export default sandboxOf(TypographyComponent).add('Typography', {
+export default sandboxOf(PgTypographyComponent).add('Typography', {
   template: `<div class="mat-drawer-container"><num-pg-typography></num-pg-typography></div>`,
 })

--- a/src/playground/pg_typography/pg_typography.component.ts
+++ b/src/playground/pg_typography/pg_typography.component.ts
@@ -5,6 +5,6 @@ import { Component } from '@angular/core'
   templateUrl: './pg_typography.component.html',
   styleUrls: ['./pg_typography.component.scss'],
 })
-export class TypographyComponent {
+export class PgTypographyComponent {
   constructor() {}
 }

--- a/src/styles/custom-material/styles/_typography.themed.scss
+++ b/src/styles/custom-material/styles/_typography.themed.scss
@@ -68,7 +68,7 @@
     letter-spacing: 0 !important;
   }
 
-  a:not(.mat-button):not(.mat-list-item):not(.mat-tab-link) {
+  a:not(.mat-button):not(.mat-list-item):not(.mat-tab-link):not(.command-bar__scenario-link) {
     color: mat-color($primary, 500);
     font-size: 16px !important;
     font-weight: 400 !important;


### PR DESCRIPTION
This PR

- adds the preview of all included icons as a playground sandbox
- removes link-styling for sandbox dropdown
- prefixes sandbox-classes with "Pg"