### PR TITLE
fix(NUM-608): Fixes code-editor expert mode input

### DIFF
--- a/src/app/modules/aqls/components/aql-editor-creator/aql-editor-creator.component.html
+++ b/src/app/modules/aqls/components/aql-editor-creator/aql-editor-creator.component.html
@@ -27,7 +27,7 @@
         <num-code-editor
           class="editor"
           style="height: 100%"
-          [value]="aqlQuery"
+          [(value)]="aqlQuery"
           (editorInit)="onEditorInit($event)"
         ></num-code-editor>
       </div>

--- a/src/app/modules/code-editor/components/code-editor/code-editor.component.ts
+++ b/src/app/modules/code-editor/components/code-editor/code-editor.component.ts
@@ -32,9 +32,13 @@ export class CodeEditorComponent implements OnInit, AfterViewInit, OnDestroy {
   private componentValue: string
 
   @Input() set value(value: string) {
-    this.componentValue = value
-    this.setValue(this.componentValue)
+    if (this.componentValue !== value) {
+      this.componentValue = value
+      this.setValue(this.componentValue)
+    }
   }
+
+  @Output() valueChange = new EventEmitter<string>()
 
   @Output() editorInit = new EventEmitter<monaco.editor.IStandaloneCodeEditor>()
 
@@ -78,6 +82,7 @@ export class CodeEditorComponent implements OnInit, AfterViewInit, OnDestroy {
   attachEditorEvents(): void {
     this.codeEditor.onDidChangeModelContent((event: monaco.editor.IModelContentChangedEvent) => {
       this.componentValue = this.codeEditor.getValue()
+      this.valueChange.emit(this.componentValue)
     })
   }
 


### PR DESCRIPTION
Fixes that manual input into the code editor was not emitted outside

**Story-Description:**
As a user I want to store a query to the platform, so that I can reuse it later