### PR TITLE
feat(NUM-643): Adds the study status to the overview table

### DIFF
--- a/src/app/modules/studies/components/studies-table/studies-table.component.html
+++ b/src/app/modules/studies/components/studies-table/studies-table.component.html
@@ -40,9 +40,11 @@
       <td mat-cell *matCellDef="let element">{{ element.name }}</td>
     </ng-container>
 
-    <ng-container matColumnDef="description">
-      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header>Description</th>
-      <td mat-cell *matCellDef="let element">{{ element.description }}</td>
+    <ng-container matColumnDef="status">
+      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header>Status</th>
+      <td mat-cell *matCellDef="let element">
+        {{ (element.status ? 'STUDY_STATUS.' + element.status : undefined) | translate }}
+      </td>
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/src/app/modules/studies/components/studies-table/studies-table.component.ts
+++ b/src/app/modules/studies/components/studies-table/studies-table.component.ts
@@ -34,7 +34,7 @@ export class StudiesTableComponent implements OnInit, AfterViewInit, OnDestroy {
     private authService: AuthService
   ) {}
 
-  displayedColumns: string[] = ['menu', 'id', 'name', 'description']
+  displayedColumns: string[] = ['menu', 'id', 'name', 'status']
   dataSource = new MatTableDataSource()
 
   menuItems: IItemVisibility[] = []

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -153,5 +153,15 @@
     "CLOSE_STUDY_CONTENT": "Wenn die Studie beendet wird, kann an den Daten nicht mehr geforscht werden.\n\nDie Studie kann nicht erneut veröffentlich werden.\n\nAlle ausgewählten Forschenden werden auch darüber informiert, dass Sie die Studie beendet haben.",
     "PUBLISH_STUDY_TITLE": "Wollen Sie die Studie wirklich veröffentlichen?",
     "PUBLISH_STUDY_CONTENT": "Nachdem Sie die Studie veröffentlicht haben, können Sie nur noch die Liste der Forscher bearbeiten.\n\nAlle ausgewählten Forschenden werden auch darüber informiert, dass Sie die Studie veröffentlicht haben."
+  },
+  "STUDY_STATUS": {
+    "APPROVED": "Genehmigt",
+    "CHANGE_REQUEST": "Änderung notwendig",
+    "CLOSED": "Geschlossen",
+    "DENIED": "Abgelehnt",
+    "DRAFT": "Entwurf",
+    "PENDING": "Genehmigung ausstehend",
+    "PUBLISHED": "Veröffentlicht",
+    "REVIEWING": "Überprüfung"
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -153,5 +153,15 @@
     "CLOSE_STUDY_CONTENT": "If the study is closed, no further research can be conducted on the data.\n\nThe study cannot be republished.\n\nAll selected researchers will also be informed that you have terminated the study.",
     "PUBLISH_STUDY_TITLE": "Do you really want to publish the study?",
     "PUBLISH_STUDY_CONTENT": "After you publish the study, you can only edit the list of researchers.\n\nAll selected researches will also be informed, that you have published the study."
+  },
+  "STUDY_STATUS": {
+    "APPROVED": "Approved",
+    "CHANGE_REQUEST": "Change request",
+    "CLOSED": "Closed",
+    "DENIED": "Denied",
+    "DRAFT": "Draft",
+    "PENDING": "Pending approval",
+    "PUBLISHED": "Published",
+    "REVIEWING": "In review"
   }
 }


### PR DESCRIPTION
This PR adds the study-status to the overview-table

**Story-Description:**
As a study coordinator I want to open my existing study, so that I can see the configured values and I am able to change.