### PR TITLE
feat(NUM-371): Formats "and", "or" to next line in aql editor

### DIFF
--- a/src/app/modules/code-editor/num-aql-formatting-provider.spec.ts
+++ b/src/app/modules/code-editor/num-aql-formatting-provider.spec.ts
@@ -21,19 +21,19 @@ describe('NumAqlFormattingProvider', () => {
     },
     {
       input: 'SELECT one and two',
-      output: 'SELECT\n  one and\n  two',
+      output: 'SELECT\n  one\n  and two',
     },
     {
       input: 'select one or two from three',
-      output: 'SELECT\n  one or\n  two\nFROM\n  three',
+      output: 'SELECT\n  one\n  or two\nFROM\n  three',
     },
     {
       input: 'select one and two from three contains four',
-      output: 'SELECT\n  one and\n  two\nFROM\n  three\n  contains four',
+      output: 'SELECT\n  one\n  and two\nFROM\n  three\n  contains four',
     },
     {
       input: 'select one contains two and contains three',
-      output: 'SELECT\n  one\n  contains two and\n  contains three',
+      output: 'SELECT\n  one\n  contains two\n  and\n  contains three',
     },
   ]
 

--- a/src/app/modules/code-editor/num-aql-formatting-provider.ts
+++ b/src/app/modules/code-editor/num-aql-formatting-provider.ts
@@ -16,8 +16,11 @@ export class NumAqlFormattingProvider {
     this.SELECT_REGEX,
     this.LIMIT_OFFSET_REGEX,
   ]
-  readonly LINE_BREAK_WORDS_FOR_CURRENT_LINE = ['contains']
-  readonly LINE_BREAK_WORDS_FOR_NEXT_LINE = ['and', 'or']
+  readonly LINE_BREAK_WORDS_FOR_CURRENT_LINE = ['contains', 'and', 'or']
+  /**
+   * Here for possible future use: Words here will be kept on the same line before line break
+   */
+  readonly LINE_BREAK_WORDS_FOR_NEXT_LINE = []
   readonly LINE_BREAK_WHITE_SPACE_FOLLOWED_CHARS = [',']
 
   readonly TAB_SIZE = 2


### PR DESCRIPTION
This PR adjusts the auto-formatting that "and" and "or" are put to the next line after line break

**Story-Description:**
As a user I want to see the AQL query formatted, so that I can easier read it.