### PR TITLE
feat(NUM-540): Adjusts date-helper test to work on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve",
     "start:hmr": "ng serve --hmr",
     "build": "node --max_old_space_size=6144 ./node_modules/.bin/ng build",
-    "test": "TZ=UTC jest",
+    "test": "jest",
     "test-ci": "JEST_JUNIT_OUTPUT_DIR=./reports/junit/ node --expose-gc ./node_modules/.bin/jest --ci -w=1 --reporters=default --reporters=jest-junit",
     "lint": "ng lint",
     "lint:fix": "ng lint --fix",

--- a/src/app/core/helper/date-helper.service.spec.ts
+++ b/src/app/core/helper/date-helper.service.spec.ts
@@ -5,11 +5,12 @@ import { DateHelperService } from './date-helper.service'
 describe('DateHelperService', () => {
   let service: DateHelperService
   const dateString = '2021-01-02T11:12:13+0000'
-  const date = new Date(dateString)
+  const date = new Date(2021, 0, 2, 11, 12, 13)
 
   beforeEach(() => {
     TestBed.configureTestingModule({})
     service = TestBed.inject(DateHelperService)
+    date.getTimezoneOffset = jest.fn().mockImplementation(() => 0)
   })
 
   it('should be created', () => {


### PR DESCRIPTION
This PR adjusts the test for the date-helper to work on windows.

Date-Helper was introduced in this story:
As a user I want to generate a WHERE clause in AQL Builder, so that I can constrain the results.