### PR TITLE
fix(NUM-1368): Fixes the rendering of researcher list if one has no role

### DIFF
--- a/src/app/modules/studies/components/dialog-add-researchers/dialog-add-researchers.component.ts
+++ b/src/app/modules/studies/components/dialog-add-researchers/dialog-add-researchers.component.ts
@@ -64,7 +64,7 @@ export class DialogAddResearchersComponent
   }
 
   handleUsersData(users: IUser[]): void {
-    this.dataSource.data = users.filter((user) => user?.roles.includes(AvailableRoles.Researcher))
+    this.dataSource.data = users.filter((user) => user.roles?.includes(AvailableRoles.Researcher))
   }
 
   handleDilaogInput(): void {


### PR DESCRIPTION
This PR fixes the issue that the list of researcher was not displayed if one user had no role assigned

Steps to reproduce:
- Click on "Add Researchers"- button in study editor
- Use search function

Expected result:
- List of available researchers is shown
- After using search the correct results are shown

Actual result:
- List is empty