### PR TITLE
feat(NUM-1267): Adds email to user search

### DIFF
--- a/src/app/core/services/admin/admin.service.spec.ts
+++ b/src/app/core/services/admin/admin.service.spec.ts
@@ -232,7 +232,7 @@ describe('AdminService', () => {
   describe('When multiple filter are passed in', () => {
     beforeEach(() => {
       jest.restoreAllMocks()
-      jest.spyOn(httpClient, 'get').mockImplementation(() => of([]))
+      jest.spyOn(httpClient, 'get').mockImplementation(() => of(mockUsers))
       throttleTime = (service as any).throttleTime
     })
 
@@ -250,25 +250,25 @@ describe('AdminService', () => {
       /* First filter call after throttle time */
       setTimeout(() => {
         service.setFilter(filterConfig)
-        expect(callHelper).toBeCalledTimes(3)
+        expect(callHelper).toBeCalledTimes(2)
       }, throttleTime + 1)
 
       setTimeout(() => {
         /* Second filter call but within throttle time */
         service.setFilter(filterConfig)
-        expect(callHelper).toHaveBeenCalledTimes(3)
+        expect(callHelper).toHaveBeenCalledTimes(2)
       }, throttleTime + 1)
 
       setTimeout(() => {
         /* Third filter call but within throttle time */
         service.setFilter(filterConfig)
-        expect(callHelper).toHaveBeenCalledTimes(3)
+        expect(callHelper).toHaveBeenCalledTimes(2)
       }, throttleTime + 10)
 
       setTimeout(() => {
         /* Fourth filter call, meanwhile the third filter was pushed */
         service.setFilter(filterConfigLast)
-        expect(callHelper).toHaveBeenCalledTimes(5)
+        expect(callHelper).toHaveBeenCalledTimes(4)
         expect(filterResult.length).toEqual(1)
         expect(filterResult[0].id).toEqual('456-789')
         done()

--- a/src/app/core/services/admin/admin.service.ts
+++ b/src/app/core/services/admin/admin.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http'
 import { Injectable } from '@angular/core'
 import { BehaviorSubject, Observable, of, throwError, forkJoin } from 'rxjs'
-import { catchError, map, switchMap, tap, throttleTime } from 'rxjs/operators'
+import { catchError, map, skip, switchMap, tap, throttleTime } from 'rxjs/operators'
 import { AppConfigService } from 'src/app/config/app-config.service'
 import { IOrganization } from 'src/app/shared/models/organization/organization.interface'
 import { IRole } from 'src/app/shared/models/user/role.interface'
@@ -40,6 +40,7 @@ export class AdminService {
 
     this.filterConfigObservable$
       .pipe(
+        skip(1),
         throttleTime(this.throttleTime, undefined, { leading: true, trailing: true }),
         switchMap((item) => this.getFilterResult$(item))
       )
@@ -143,7 +144,8 @@ export class AdminService {
           user.lastName?.toUpperCase().includes(textFilter) ||
           user.firstName?.toUpperCase().includes(textFilter) ||
           user.firstName?.concat(' ', user.lastName).toUpperCase().includes(textFilter) ||
-          user.lastName?.concat(' ', user.firstName).toUpperCase().includes(textFilter)
+          user.lastName?.concat(' ', user.firstName).toUpperCase().includes(textFilter) ||
+          user.email.toUpperCase().includes(textFilter)
       )
     }
 

--- a/src/app/modules/user-management/components/approved-users/approved-users.component.ts
+++ b/src/app/modules/user-management/components/approved-users/approved-users.component.ts
@@ -11,14 +11,17 @@ import { IUserFilter } from 'src/app/shared/models/user/user-filter.interface'
 export class ApprovedUsersComponent implements OnInit {
   filterConfig: IUserFilter
 
-  constructor(private adminService: AdminService) {
-    this.adminService.filterConfigObservable$
-      .pipe(take(1))
-      .subscribe((config) => (this.filterConfig = config))
-  }
+  constructor(private adminService: AdminService) {}
 
   ngOnInit(): void {
+    this.setLastFilter()
     this.adminService.getApprovedUsers().subscribe()
+  }
+
+  setLastFilter(): void {
+    this.adminService.filterConfigObservable$.pipe(take(1)).subscribe((config) => {
+      this.filterConfig = config
+    })
   }
 
   handleSearchChange(): void {


### PR DESCRIPTION
This PR adds the email adress to the user search.

As an Organization Admin or Super Admin I can search for a user by name or email address and I can manually sort the table columns.
