### PR TITLE
feat(NUM-1450): Hides custom configuration and determine hits

### DIFF
--- a/src/app/modules/data-explorer/components/data-explorer/data-explorer.component.html
+++ b/src/app/modules/data-explorer/components/data-explorer/data-explorer.component.html
@@ -56,7 +56,9 @@
       [attr.data-test]="'data-explorer__get-data-button'"
       >{{ 'BUTTON.GET_DATA' | translate }}</num-button
     >
+    <!-- NUM-1450: Custom configuration is not shown for Release 1.0 -->
     <num-button
+      [hidden]="true"
       [isDisabled]="!isCompositionsFetched || isDataSetLoading"
       type="secondary"
       icon="pen"

--- a/src/app/modules/projects/components/project-editor-connector/project-editor-connector.component.html
+++ b/src/app/modules/projects/components/project-editor-connector/project-editor-connector.component.html
@@ -51,7 +51,9 @@
       data-test="project-editor__connector__group"
     ></num-project-editor-connector-group>
 
+    <!-- NUM-1450: Determine Hits in Data Explorer is not shown for Release 1.0 -->
     <num-editor-determine-hits
+      [hidden]="!determineHitsContent"
       [isButtonDisabled]="!(cohortNode.children.length && cohortNode.areParameterConfigured)"
       [content]="determineHitsContent"
       (clicked)="determineHitsClicked.emit()"


### PR DESCRIPTION
This PR hides the *Custom Configuration* Button and the *Determine Hits* Button in the Data Explorer.