### PR TITLE
feat(NUM-1496): Adds sorting for Data Explorer Projects

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Jest All",
+        "type": "node",
+        "request": "launch",
+        "cwd": "${workspaceFolder:num-portal-webapp}",
+        "args": ["--runInBand"],
+        "console": "integratedTerminal",
+        "internalConsoleOptions": "neverOpen",
+        "disableOptimisticBPs": true,
+        "program": "${workspaceFolder:num-portal-webapp}/node_modules/jest/bin/jest"
+      },
+      {
+        "type": "node",
+        "name": "Jest current file",
+        "request": "launch",
+        "args": ["${fileBasenameNoExtension}", "--coverage=false"],
+        "cwd": "${workspaceFolder:num-portal-webapp}",
+        "console": "integratedTerminal",
+        "internalConsoleOptions": "neverOpen",
+        "disableOptimisticBPs": true,
+        "program": "${workspaceFolder:num-portal-webapp}/node_modules/jest/bin/jest"
+      }
+    ]
+}

--- a/src/app/core/utils/sort.utils.ts
+++ b/src/app/core/utils/sort.utils.ts
@@ -15,6 +15,10 @@
  */
 
 import { MatSort } from '@angular/material/sort'
+import { TranslateService } from '@ngx-translate/core'
+import { DataExplorerProjectTableColumns } from 'src/app/shared/models/project/data-explorer-project-table.interface'
+import { IProjectApi } from 'src/app/shared/models/project/project-api.interface'
+import { ProjectTableColumns } from 'src/app/shared/models/project/project-table.interface'
 import { ApprovedUsersTableColumn } from 'src/app/shared/models/user/approved-table-column.interface'
 import { UnapprovedUsersTableColumn } from 'src/app/shared/models/user/unapproved-table-column.interface'
 import { IUser } from 'src/app/shared/models/user/user.interface'
@@ -166,6 +170,79 @@ export const sortUsers = (data: IUser[], sort: MatSort): IUser[] => {
     }
     default: {
       return newData.sort((a, b) => compareIds(a.id, b.id, isAsc))
+    }
+  }
+}
+
+/**
+ * Sorts all project related lists by the given sort directive. Can be used for all project lists.
+ * TranslationService is optional
+ *
+ * @param data - Project array
+ * @param sort - Sort info from sortHeader
+ * @param translateService - To translate certain values
+ */
+export const sortProjects = (
+  data: IProjectApi[],
+  sort: MatSort,
+  translateService?: TranslateService
+): IProjectApi[] => {
+  const isAsc = sort.direction === 'asc'
+  const newData = [...data]
+
+  switch (sort.active as ProjectTableColumns | DataExplorerProjectTableColumns) {
+    case 'author': {
+      return newData.sort((a, b) =>
+        compareLocaleStringValues(
+          `${a.coordinator?.firstName || ''} ${a.coordinator?.lastName || ''}`,
+          `${b.coordinator?.firstName || ''} ${b.coordinator?.lastName || ''}`,
+          a.id,
+          b.id,
+          isAsc
+        )
+      )
+    }
+    case 'name': {
+      return newData.sort((a, b) => compareLocaleStringValues(a.name, b.name, a.id, b.id, isAsc))
+    }
+    case 'organization': {
+      return newData.sort((a, b) =>
+        compareLocaleStringValues(
+          `${a.coordinator?.organization?.name || ''}`,
+          `${b.coordinator?.organization?.name || ''}`,
+          a.id,
+          b.id,
+          isAsc
+        )
+      )
+    }
+    case 'status': {
+      return newData.sort((a, b) =>
+        compareLocaleStringValues(
+          translateService?.instant(`PROJECT.STATUS.${a.status}`) || a.status,
+          translateService?.instant(`PROJECT.STATUS.${b.status}`) || b.status,
+          a.id,
+          b.id,
+          isAsc
+        )
+      )
+    }
+    case 'createDate': {
+      return newData.sort((a, b) =>
+        compareLocaleStringValues(
+          `${a.createDate || ''}`,
+          `${b.createDate || ''}`,
+          a.id,
+          b.id,
+          isAsc
+        )
+      )
+    }
+    default: {
+      return newData.sort((a, b) => {
+        const compareResult = a.id - b.id
+        return isAsc ? compareResult : compareResult * -1
+      })
     }
   }
 }

--- a/src/app/modules/data-explorer/components/data-explorer-projects-table/data-explorer-projects-table.component.html
+++ b/src/app/modules/data-explorer/components/data-explorer-projects-table/data-explorer-projects-table.component.html
@@ -17,7 +17,17 @@
 <h3 id="projects-header">{{ 'AVAILABLE_PROJECTS' | translate }}</h3>
 
 <div role="presentation" class="mat-elevation-z1 num-margin-b-60">
-  <table aria-labelledby="projects-header" mat-table [dataSource]="dataSource" fixedLayout matSort>
+  <table
+    aria-labelledby="projects-header"
+    mat-table
+    [dataSource]="dataSource"
+    fixedLayout
+    matSort
+    matSortActive="id"
+    matSortDirection="desc"
+    (matSortChange)="handleSortChange($event)"
+    data-test="data-explorer-projects__table"
+  >
     <ng-container matColumnDef="icon">
       <th scope="col" mat-header-cell *matHeaderCellDef class="width-sm">
         {{ 'FORM.ACTION' | translate }}
@@ -28,21 +38,33 @@
           mat-icon-button
           [attr.aria-label]="'BUTTON.SELECT' | translate"
           (click)="handleSelectClick(element.id)"
-          data-test="data-explorer-studies__table__select-button"
+          data-test="data-explorer-projects__table__select-button"
         >
           <fa-icon icon="external-link-alt" size="lg" [fixedWidth]="true"></fa-icon>
         </button>
       </td>
     </ng-container>
 
-    <ng-container matColumnDef="title">
+    <!-- ID column is only for default sorting and will not be displayed -->
+    <ng-container matColumnDef="id">
+      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header>ID</th>
+      <td
+        mat-cell
+        *matCellDef="let element"
+        data-test="data-explorer-projects__table-data__project-id"
+      >
+        {{ element.id }}
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="name">
       <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header>
         {{ 'FORM.TITLE' | translate }}
       </th>
       <td mat-cell *matCellDef="let element">{{ element.name }}</td>
     </ng-container>
 
-    <ng-container matColumnDef="coordinatorName">
+    <ng-container matColumnDef="author">
       <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header>
         {{ 'FORM.AUTHOR' | translate }}
       </th>
@@ -51,7 +73,7 @@
       </td>
     </ng-container>
 
-    <ng-container matColumnDef="coordinatorOrganization">
+    <ng-container matColumnDef="organization">
       <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header>
         {{ 'USER.ORGANIZATION' | translate }}
       </th>

--- a/src/app/modules/data-explorer/components/data-explorer-projects-table/data-explorer-projects-table.component.spec.ts
+++ b/src/app/modules/data-explorer/components/data-explorer-projects-table/data-explorer-projects-table.component.spec.ts
@@ -14,18 +14,24 @@
  * limitations under the License.
  */
 
+import { HarnessLoader } from '@angular/cdk/testing'
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed'
+import { Pipe, PipeTransform } from '@angular/core'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { MatSortHeaderHarness } from '@angular/material/sort/testing'
+import { MatTableHarness } from '@angular/material/table/testing'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 import { Router } from '@angular/router'
 import { RouterTestingModule } from '@angular/router/testing'
 import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing'
 import { TranslateModule } from '@ngx-translate/core'
+import { maxBy, minBy } from 'lodash-es'
 import { Subject } from 'rxjs'
 import { ProjectService } from 'src/app/core/services/project/project.service'
 import { MaterialModule } from 'src/app/layout/material/material.module'
 import { IProjectApi } from 'src/app/shared/models/project/project-api.interface'
 import { PipesModule } from 'src/app/shared/pipes/pipes.module'
-import { mockProject3 } from 'src/mocks/data-mocks/project.mock'
+import { mockProject3, mockProjectsForSort } from 'src/mocks/data-mocks/project.mock'
 
 import { DataExplorerProjectsTableComponent } from './data-explorer-projects-table.component'
 
@@ -34,6 +40,13 @@ describe('DataExplorerProjectsTableComponent', () => {
   let fixture: ComponentFixture<DataExplorerProjectsTableComponent>
   let router: Router
 
+  @Pipe({ name: 'localizedDate' })
+  class MockLocalizedDatePipe implements PipeTransform {
+    transform(value: number): number {
+      return value
+    }
+  }
+
   const myPublishedProjectsSubject$ = new Subject<IProjectApi[]>()
   const projectService = ({
     myPublishedProjectsObservable$: myPublishedProjectsSubject$.asObservable(),
@@ -41,7 +54,7 @@ describe('DataExplorerProjectsTableComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [DataExplorerProjectsTableComponent],
+      declarations: [DataExplorerProjectsTableComponent, MockLocalizedDatePipe],
       imports: [
         MaterialModule,
         BrowserAnimationsModule,
@@ -86,6 +99,126 @@ describe('DataExplorerProjectsTableComponent', () => {
       const projectId = 1
       component.handleSelectClick(projectId)
       expect(router.navigate).toHaveBeenCalledWith(['data-explorer/projects', projectId])
+    })
+  })
+
+  describe('When sorting table', () => {
+    let loader: HarnessLoader
+    let table: MatTableHarness
+
+    beforeEach(async () => {
+      loader = TestbedHarnessEnvironment.loader(fixture)
+      component.pageSize = 40
+      fixture.detectChanges()
+      myPublishedProjectsSubject$.next(mockProjectsForSort)
+      table = await loader.getHarness(MatTableHarness)
+    })
+
+    it('should sort by id descending as default', async () => {
+      component.displayedColumns.push('id')
+      const orgMinId = minBy(mockProjectsForSort, 'id')
+      const orgMaxId = maxBy(mockProjectsForSort, 'id')
+
+      const rows = await table.getCellTextByColumnName()
+
+      expect(rows.id.text).toHaveLength(mockProjectsForSort.length)
+      expect(rows.id.text[0]).toEqual(orgMaxId.id.toString())
+      expect(rows.id.text[rows.id.text.length - 1]).toEqual(orgMinId.id.toString())
+    })
+
+    it('should be able to sort by name asc', async () => {
+      const sortHeader = await loader.getHarness(
+        MatSortHeaderHarness.with({ selector: '.mat-column-name' })
+      )
+
+      await sortHeader.click()
+      const rows = await table.getCellTextByColumnName()
+
+      expect(await sortHeader.getSortDirection()).toEqual('asc')
+      expect(rows.name.text[0]).toEqual('')
+      expect(rows.name.text[rows.name.text.length - 1]).toEqual('Test project ü')
+    })
+
+    it('should be able to sort by name desc', async () => {
+      const sortHeader = await loader.getHarness(
+        MatSortHeaderHarness.with({ selector: '.mat-column-name' })
+      )
+
+      // Default: "", first click: ASC, second click: DESC
+      await sortHeader.click()
+      await sortHeader.click()
+      const rows = await table.getCellTextByColumnName()
+
+      expect(await sortHeader.getSortDirection()).toEqual('desc')
+      expect(rows.name.text[0]).toEqual('Test project ü')
+      expect(rows.name.text[rows.name.text.length - 1]).toEqual('')
+    })
+
+    it('should be able to sort by createDate asc', async () => {
+      component.displayedColumns.push('id')
+      const sortHeader = await loader.getHarness(
+        MatSortHeaderHarness.with({ selector: '.mat-column-createDate' })
+      )
+
+      await sortHeader.click()
+      const rows = await table.getCellTextByColumnName()
+
+      expect(await sortHeader.getSortDirection()).toEqual('asc')
+      expect(parseInt(rows.id.text[0], 10)).toEqual(6)
+      expect(parseInt(rows.id.text[rows.name.text.length - 1], 10)).toEqual(21)
+    })
+
+    it('should be able to sort by createDate desc', async () => {
+      component.displayedColumns.push('id')
+      const sortHeader = await loader.getHarness(
+        MatSortHeaderHarness.with({ selector: '.mat-column-createDate' })
+      )
+
+      // Default: "", first click: ASC, second click: DESC
+      await sortHeader.click()
+      await sortHeader.click()
+      const rows = await table.getCellTextByColumnName()
+
+      expect(await sortHeader.getSortDirection()).toEqual('desc')
+      expect(parseInt(rows.id.text[0], 10)).toEqual(21)
+      expect(parseInt(rows.id.text[rows.name.text.length - 1], 10)).toEqual(6)
+    })
+
+    it('should sort by order empty -> special charactes -> numbers -> alphabetical', async () => {
+      const sortHeader = await loader.getHarness(
+        MatSortHeaderHarness.with({ selector: '.mat-column-name' })
+      )
+
+      await sortHeader.click()
+      const rows = await table.getCellTextByColumnName()
+
+      expect(rows.name.text[0]).toEqual('')
+      expect(rows.name.text[1]).toEqual('%')
+      expect(rows.name.text[2]).toEqual('1')
+      expect(rows.name.text[3]).toEqual('a')
+    })
+
+    it('should sort equal entries by id in same direction as selected', async () => {
+      component.displayedColumns.push('id')
+      const sortHeader = await loader.getHarness(
+        MatSortHeaderHarness.with({ selector: '.mat-column-author' })
+      )
+
+      await sortHeader.click()
+      let rows = await table.getCellTextByColumnName()
+      let firstIdx = rows.author.text.findIndex((txt) => 'Max Mustermann' === txt)
+
+      expect(parseInt(rows.id.text[firstIdx], 10)).toBeLessThan(
+        parseInt(rows.id.text[firstIdx + 1], 10)
+      )
+
+      await sortHeader.click()
+      rows = await table.getCellTextByColumnName()
+      firstIdx = rows.author.text.findIndex((txt) => 'Max Mustermann' === txt)
+
+      expect(parseInt(rows.id.text[firstIdx], 10)).toBeGreaterThan(
+        parseInt(rows.id.text[firstIdx + 1], 10)
+      )
     })
   })
 })

--- a/src/app/modules/data-explorer/components/data-explorer-projects-table/data-explorer-projects-table.component.ts
+++ b/src/app/modules/data-explorer/components/data-explorer-projects-table/data-explorer-projects-table.component.ts
@@ -21,22 +21,29 @@ import { MatTableDataSource } from '@angular/material/table'
 import { Router } from '@angular/router'
 import { Subscription } from 'rxjs'
 import { ProjectService } from 'src/app/core/services/project/project.service'
+import { sortProjects } from 'src/app/core/utils/sort.utils'
+import { DataExplorerProjectTableColumns } from 'src/app/shared/models/project/data-explorer-project-table.interface'
 import { IProjectApi } from 'src/app/shared/models/project/project-api.interface'
+import { SortableTable } from 'src/app/shared/models/sortable-table.model'
 
 @Component({
   selector: 'num-data-explorer-projects-table',
   templateUrl: './data-explorer-projects-table.component.html',
   styleUrls: ['./data-explorer-projects-table.component.scss'],
 })
-export class DataExplorerProjectsTableComponent implements OnInit, AfterViewInit, OnDestroy {
+export class DataExplorerProjectsTableComponent
+  extends SortableTable<IProjectApi>
+  implements OnInit, AfterViewInit, OnDestroy {
   private subscriptions = new Subscription()
-  constructor(private projectService: ProjectService, private router: Router) {}
+  constructor(private projectService: ProjectService, private router: Router) {
+    super()
+  }
 
-  displayedColumns: string[] = [
+  displayedColumns: DataExplorerProjectTableColumns[] = [
     'icon',
-    'title',
-    'coordinatorName',
-    'coordinatorOrganization',
+    'name',
+    'author',
+    'organization',
     'createDate',
   ]
   dataSource = new MatTableDataSource()
@@ -62,6 +69,7 @@ export class DataExplorerProjectsTableComponent implements OnInit, AfterViewInit
 
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator
+    this.dataSource.sortData = (data, matSort) => sortProjects(data, matSort)
     this.dataSource.sort = this.sort
   }
 

--- a/src/app/modules/projects/components/projects-table/projects-table.component.html
+++ b/src/app/modules/projects/components/projects-table/projects-table.component.html
@@ -77,7 +77,7 @@
             [matMenuTriggerData]="{
               projectStatus: element.status,
               id: element.id,
-              ownerId: element.coordinator.id
+              ownerId: element.coordinator?.id
             }"
             data-test="projects__table__action-menu-button"
           >

--- a/src/app/modules/projects/components/projects-table/projects-table.component.spec.ts
+++ b/src/app/modules/projects/components/projects-table/projects-table.component.spec.ts
@@ -383,6 +383,7 @@ describe('ProjectsTableComponent', () => {
       const tableRows = Array.from(ascQueryResult) as HTMLTableCellElement[]
       const idx = tableRows.findIndex((r) => r.innerHTML === ' Marianne Musterfrau ')
       expect(tableRows[idx + 1].innerHTML).toEqual(' Max Mustermann ')
+      expect(tableRows[idx - 1].innerHTML).toEqual('  - ')
     })
 
     it('should sort by author descending', () => {
@@ -394,6 +395,7 @@ describe('ProjectsTableComponent', () => {
       const tableRows = Array.from(descQueryResult) as HTMLTableCellElement[]
       const idx = tableRows.findIndex((r) => r.innerHTML === ' Marianne Musterfrau ')
       expect(tableRows[idx - 1].innerHTML).toEqual(' Max Mustermann ')
+      expect(tableRows[idx + 1].innerHTML).toEqual('  - ')
     })
   })
 })

--- a/src/app/modules/projects/components/projects-table/projects-table.component.ts
+++ b/src/app/modules/projects/components/projects-table/projects-table.component.ts
@@ -25,7 +25,7 @@ import { DialogService } from 'src/app/core/services/dialog/dialog.service'
 import { ProfileService } from 'src/app/core/services/profile/profile.service'
 import { ProjectService } from 'src/app/core/services/project/project.service'
 import { ToastMessageService } from 'src/app/core/services/toast-message/toast-message.service'
-import { compareLocaleStringValues } from 'src/app/core/utils/sort.utils'
+import { sortProjects } from 'src/app/core/utils/sort.utils'
 import { AvailableRoles } from 'src/app/shared/models/available-roles.enum'
 import { DialogConfig } from 'src/app/shared/models/dialog/dialog-config.interface'
 import { IItemVisibility } from 'src/app/shared/models/item-visibility.interface'
@@ -105,7 +105,7 @@ export class ProjectsTableComponent
   ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator
 
-    this.dataSource.sortData = (data, matSort) => this.sortData(data, matSort)
+    this.dataSource.sortData = (data, matSort) => sortProjects(data, matSort, this.translateService)
 
     this.dataSource.sort = this.sort
   }
@@ -200,55 +200,5 @@ export class ProjectsTableComponent
           .subscribe()
       }
     })
-  }
-
-  sortData(data: IProjectApi[], sort: MatSort): IProjectApi[] {
-    const isAsc = sort.direction === 'asc'
-    const newData = [...data]
-
-    switch (sort.active as ProjectTableColumns) {
-      case 'author': {
-        return newData.sort((a, b) =>
-          compareLocaleStringValues(
-            `${a.coordinator?.firstName || ''} ${a.coordinator?.lastName || ''}`,
-            `${b.coordinator?.firstName} ${b.coordinator?.lastName}`,
-            a.id,
-            b.id,
-            isAsc
-          )
-        )
-      }
-      case 'name': {
-        return newData.sort((a, b) => compareLocaleStringValues(a.name, b.name, a.id, b.id, isAsc))
-      }
-      case 'organization': {
-        return newData.sort((a, b) =>
-          compareLocaleStringValues(
-            `${a.coordinator?.organization?.name || ''}`,
-            `${b.coordinator?.organization?.name || ''}`,
-            a.id,
-            b.id,
-            isAsc
-          )
-        )
-      }
-      case 'status': {
-        return newData.sort((a, b) =>
-          compareLocaleStringValues(
-            this.translateService.instant(`PROJECT.STATUS.${a.status}`),
-            this.translateService.instant(`PROJECT.STATUS.${b.status}`),
-            a.id,
-            b.id,
-            isAsc
-          )
-        )
-      }
-      default: {
-        return newData.sort((a, b) => {
-          const compareResult = a.id - b.id
-          return isAsc ? compareResult : compareResult * -1
-        })
-      }
-    }
   }
 }

--- a/src/app/shared/models/project/data-explorer-project-table.interface.ts
+++ b/src/app/shared/models/project/data-explorer-project-table.interface.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2021 Vitagroup AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type DataExplorerProjectTableColumns =
+  | 'icon'
+  | 'name'
+  | 'author'
+  | 'organization'
+  | 'createDate'
+  | 'id'

--- a/src/mocks/data-mocks/project.mock.ts
+++ b/src/mocks/data-mocks/project.mock.ts
@@ -146,7 +146,7 @@ export const mockProject6: IProjectApi = {
   ],
   firstHypotheses: 'Test Hypothesis 6',
   status: ProjectStatus.Pending,
-  createDate: DateHelperService.getDateString(new Date()),
+  createDate: DateHelperService.getDateString(new Date(2000, 2, 1)),
   modifiedDate: DateHelperService.getDateString(new Date()),
 }
 
@@ -390,7 +390,7 @@ export const mockProject20: IProjectApi = {
   description: 'Test project for testing numeric sorting',
   templates: [],
   cohortId: 20,
-  coordinator: mockUserSuperAdmin,
+  coordinator: undefined,
   researchers: [
     {
       userId: 'abc-1',
@@ -416,7 +416,7 @@ export const mockProject21: IProjectApi = {
   ],
   firstHypotheses: 'Test Hypothesis 21',
   status: ProjectStatus.Draft,
-  createDate: DateHelperService.getDateString(new Date()),
+  createDate: DateHelperService.getDateString(new Date(2036, 3, 6)),
   modifiedDate: DateHelperService.getDateString(new Date()),
 }
 


### PR DESCRIPTION
This PR adds sorting for projects in the data-explorer page.

**Story-Description:**
As a user I want to sort tables by clicking the column, so that I can easily view the content