### PR TITLE
feat(NUM-1579): Adds template restriction in aql builder

### DIFF
--- a/src/app/modules/aqls/components/aql-builder-contains-group/aql-builder-contains-group.component.html
+++ b/src/app/modules/aqls/components/aql-builder-contains-group/aql-builder-contains-group.component.html
@@ -54,7 +54,7 @@
     [parentGroupIndex]="groupIndex"
     [index]="i"
     (delete)="deleteChildGroup($event)"
-    (deleteArchetypes)="this.deleteArchetypes.emit($event)"
+    (deleteArchetypesByReferenceIds)="this.deleteArchetypes.emit($event)"
     data-test="aqb__contains__group"
   ></num-aql-builder-contains-group>
 
@@ -65,7 +65,7 @@
     }"
     *ngIf="child.type === connectorNodeType.Aqb_Item"
     [item]="child"
-    (deleteItem)="deleteChildItem(i, $event)"
+    (deleteItemByArchetypeReferenceId)="deleteChildItem(i, $event)"
     fxFlex="100%"
     role="listitem"
     fxLayout="row"

--- a/src/app/modules/aqls/components/aql-builder-contains-group/aql-builder-contains-group.component.spec.ts
+++ b/src/app/modules/aqls/components/aql-builder-contains-group/aql-builder-contains-group.component.spec.ts
@@ -122,30 +122,31 @@ describe('AqlBuilderContainsGroupComponent', () => {
     it('should emit the composition id if its a composition', () => {
       const compId = 'testCompositionId'
       const templId = 'testTemplateId'
-      component.group = new AqbContainsCompositionUiModel(templId, compId, 1)
-      jest.spyOn(component.deleteComposition, 'emit')
+      const compReferenceId = 1
+      component.group = new AqbContainsCompositionUiModel(templId, compId, compReferenceId)
+      jest.spyOn(component.deleteCompositionByReferenceId, 'emit')
       component.deleteSelf()
-      expect(component.deleteComposition.emit).toHaveBeenCalledWith(compId)
+      expect(component.deleteCompositionByReferenceId.emit).toHaveBeenCalledWith(compReferenceId)
     })
   })
 
   describe('When a child item is supposed to be deleted from the group', () => {
     beforeEach(() => {
-      jest.spyOn(component.deleteArchetypes, 'emit')
+      jest.spyOn(component.deleteArchetypesByReferenceIds, 'emit')
       component.group = new AqbContainsGroupUiModel()
       const child1 = new AqbContainsItemUiModel('testComp1', 1, 'testArchetypeId1', 2)
       const child2 = new AqbContainsItemUiModel('testComp2', 3, 'testArchetypeId2', 4)
       component.group.children = [child1, child2]
 
-      component.deleteChildItem(1, 'testArchetypeId1')
+      component.deleteChildItem(1, 4)
     })
 
     it('should delete the item from the group based on its index', () => {
       expect(component.group.children.length).toEqual(1)
     })
 
-    it('should emit the archetypeId to the parent', () => {
-      expect(component.deleteArchetypes.emit).toHaveBeenCalledWith(['testArchetypeId1'])
+    it('should emit the archetypeReferenceId to the parent', () => {
+      expect(component.deleteArchetypesByReferenceIds.emit).toHaveBeenCalledWith([4])
     })
   })
 })

--- a/src/app/modules/aqls/components/aql-builder-contains-group/aql-builder-contains-group.component.ts
+++ b/src/app/modules/aqls/components/aql-builder-contains-group/aql-builder-contains-group.component.ts
@@ -49,8 +49,8 @@ export class AqlBuilderContainsGroupComponent implements OnInit, OnChanges {
   @Input() index: number
 
   @Output() delete = new EventEmitter<number>()
-  @Output() deleteArchetypes = new EventEmitter<string[]>()
-  @Output() deleteComposition = new EventEmitter<string>()
+  @Output() deleteArchetypesByReferenceIds = new EventEmitter<number[]>()
+  @Output() deleteCompositionByReferenceId = new EventEmitter<number>()
 
   enumerateGroupsDebounced = debounce(() => this.enumerateGroups(), 100, {
     leading: true,
@@ -99,19 +99,19 @@ export class AqlBuilderContainsGroupComponent implements OnInit, OnChanges {
 
   deleteChildGroup(index: number): void {
     const deletedGroup = this.group.children.splice(index, 1)[0] as AqbContainsGroupUiModel
-    const archetypeIds = deletedGroup.collectArchetypeReferences([])
-    this.deleteArchetypes.emit(archetypeIds)
+    const archetypeReferenceIds = deletedGroup.collectArchetypeReferenceIds([])
+    this.deleteArchetypesByReferenceIds.emit(archetypeReferenceIds)
     this.enumerateGroupsDebounced()
   }
 
-  deleteChildItem(index: number, archetypeId: string): void {
+  deleteChildItem(index: number, archetypeReferenceId: number): void {
     this.group.children.splice(index, 1)
-    this.deleteArchetypes.emit([archetypeId])
+    this.deleteArchetypesByReferenceIds.emit([archetypeReferenceId])
   }
 
   deleteSelf(): void {
     if (this.group instanceof AqbContainsCompositionUiModel) {
-      this.deleteComposition.emit(this.group.compositionId)
+      this.deleteCompositionByReferenceId.emit(this.group.compositionReferenceId)
     } else {
       this.delete.emit(this.index)
     }

--- a/src/app/modules/aqls/components/aql-builder-contains-item/aql-builder-contains-item.component.spec.ts
+++ b/src/app/modules/aqls/components/aql-builder-contains-item/aql-builder-contains-item.component.spec.ts
@@ -63,10 +63,12 @@ describe('AqlBuilderContainsItemComponent', () => {
   })
 
   describe('When the item is supposed to be deleted', () => {
-    it('should emit its archetypeId to its parent', () => {
-      jest.spyOn(component.deleteItem, 'emit')
+    it('should emit its archetypeReferenceId to its parent', () => {
+      jest.spyOn(component.deleteItemByArchetypeReferenceId, 'emit')
       component.deleteSelf()
-      expect(component.deleteItem.emit).toHaveBeenCalledWith(archetypeId)
+      expect(component.deleteItemByArchetypeReferenceId.emit).toHaveBeenCalledWith(
+        archetypeReferenceId
+      )
     })
   })
 })

--- a/src/app/modules/aqls/components/aql-builder-contains-item/aql-builder-contains-item.component.ts
+++ b/src/app/modules/aqls/components/aql-builder-contains-item/aql-builder-contains-item.component.ts
@@ -29,11 +29,11 @@ export class AqlBuilderContainsItemComponent implements OnInit {
   item: AqbContainsItemUiModel
 
   @Output()
-  deleteItem = new EventEmitter<string>()
+  deleteItemByArchetypeReferenceId = new EventEmitter<number>()
 
   ngOnInit(): void {}
 
   deleteSelf(): void {
-    this.deleteItem.emit(this.item.archetypeId)
+    this.deleteItemByArchetypeReferenceId.emit(this.item.archetypeReferenceId)
   }
 }

--- a/src/app/modules/aqls/components/aql-builder-contains/aql-builder-contains.component.html
+++ b/src/app/modules/aqls/components/aql-builder-contains/aql-builder-contains.component.html
@@ -24,8 +24,8 @@
     [group]="composition"
     [parentGroupIndex]="null"
     [index]="i"
-    (deleteArchetypes)="deleteArchetypes($event)"
-    (deleteComposition)="deleteComposition($event)"
+    (deleteArchetypesByReferenceIds)="deleteArchetypesByReferenceIds($event)"
+    (deleteCompositionByReferenceId)="deleteCompositionByReferenceId($event)"
     data-test="aqb__contains__group"
   ></num-aql-builder-contains-group>
 </div>

--- a/src/app/modules/aqls/components/aql-builder-contains/aql-builder-contains.component.spec.ts
+++ b/src/app/modules/aqls/components/aql-builder-contains/aql-builder-contains.component.spec.ts
@@ -32,16 +32,18 @@ describe('AqlBuilderContainsComponent', () => {
     @Input() group: any
     @Input() parentGroupIndex: any
     @Input() index: any
-    @Output() deleteArchetypes = deleteArchetypeEmitter
-    @Output() deleteComposition = deleteCompositionEmitter
+    @Output() deleteArchetypesByReferenceIds = deleteArchetypeEmitter
+    @Output() deleteCompositionByReferenceId = deleteCompositionEmitter
   }
 
   const mockComposition1 = {
     compositionId: 'test1',
+    compositionReferenceId: 1,
   } as AqbContainsCompositionUiModel
 
   const mockComposition2 = {
     compositionId: 'test2',
+    compositionReferenceId: 2,
   } as AqbContainsCompositionUiModel
 
   const mockCompositions = [mockComposition1, mockComposition2]
@@ -66,11 +68,11 @@ describe('AqlBuilderContainsComponent', () => {
 
   describe('When a composition is supposed to be deleted on behalf of the child group', () => {
     beforeEach(() => {
-      jest.spyOn(component.aqbModel, 'handleDeletionByComposition').mockImplementation()
-      deleteCompositionEmitter.emit('test1')
+      jest.spyOn(component.aqbModel, 'handleDeletionByCompositionReferenceIds').mockImplementation()
+      deleteCompositionEmitter.emit(1)
     })
     it('should call the aqbModel to handle the deletion by composition', () => {
-      expect(component.aqbModel.handleDeletionByComposition).toHaveBeenCalledWith(['test1'])
+      expect(component.aqbModel.handleDeletionByCompositionReferenceIds).toHaveBeenCalledWith([1])
     })
 
     it('should filter the compositions to keep the other compositions and delete the desired composition', () => {
@@ -81,11 +83,13 @@ describe('AqlBuilderContainsComponent', () => {
 
   describe('When an archetype root element is supposed to be deleted on behalf of the item', () => {
     beforeEach(() => {
-      jest.spyOn(component.aqbModel, 'handleDeletionByArchetype').mockImplementation()
+      jest.spyOn(component.aqbModel, 'handleDeletionByArchetypeReferenceIds').mockImplementation()
       deleteArchetypeEmitter.emit(['test1'])
     })
     it('should call the aqbModel to handle the deletion by archetype', () => {
-      expect(component.aqbModel.handleDeletionByArchetype).toHaveBeenCalledWith(['test1'])
+      expect(component.aqbModel.handleDeletionByArchetypeReferenceIds).toHaveBeenCalledWith([
+        'test1',
+      ])
     })
   })
 })

--- a/src/app/modules/aqls/components/aql-builder-contains/aql-builder-contains.component.ts
+++ b/src/app/modules/aqls/components/aql-builder-contains/aql-builder-contains.component.ts
@@ -34,14 +34,14 @@ export class AqlBuilderContainsComponent implements OnInit {
 
   ngOnInit(): void {}
 
-  deleteComposition(compositionId: string): void {
-    this.aqbModel.handleDeletionByComposition([compositionId])
+  deleteCompositionByReferenceId(compositionReferenceId: number): void {
+    this.aqbModel.handleDeletionByCompositionReferenceIds([compositionReferenceId])
     this.compositions = this.compositions.filter(
-      (composition) => composition.compositionId !== compositionId
+      (composition) => composition.compositionReferenceId !== compositionReferenceId
     )
   }
 
-  deleteArchetypes(archetypeIds: string[]): void {
-    this.aqbModel.handleDeletionByArchetype(archetypeIds)
+  deleteArchetypesByReferenceIds(archetypeReferenceIds: number[]): void {
+    this.aqbModel.handleDeletionByArchetypeReferenceIds(archetypeReferenceIds)
   }
 }

--- a/src/app/modules/aqls/components/aql-builder-where/aql-builder-where.component.html
+++ b/src/app/modules/aqls/components/aql-builder-where/aql-builder-where.component.html
@@ -30,11 +30,11 @@
 
 <div class="num-aqb-box" fxLayout="column" fxLayoutGap="20px">
   <num-aql-builder-where-group
-    *ngIf="aqbModel.where.children.length"
+    *ngIf="$any(aqbModel.where.children[1])?.children.length"
     role="list"
     class="group"
     [dialogMode]="dialogMode"
-    [group]="aqbModel.where"
+    [group]="aqbModel.where.children[1]"
     [parentGroupIndex]="null"
     data-test="aqb__where__group"
   ></num-aql-builder-where-group>

--- a/src/app/modules/aqls/models/aqb/aqb-contains-group-ui.model.ts
+++ b/src/app/modules/aqls/models/aqb/aqb-contains-group-ui.model.ts
@@ -55,14 +55,14 @@ export class AqbContainsGroupUiModel {
     }
   }
 
-  collectArchetypeReferences(references: string[]): string[] {
+  collectArchetypeReferenceIds(referenceIds: number[]): number[] {
     return this.children.reduce((arr, item) => {
       if (item instanceof AqbContainsItemUiModel) {
-        arr.push(item.archetypeId)
+        arr.push(item.archetypeReferenceId)
         return arr
       } else {
-        return item.collectArchetypeReferences(arr)
+        return item.collectArchetypeReferenceIds(arr)
       }
-    }, references)
+    }, referenceIds)
   }
 }

--- a/src/app/modules/aqls/models/aqb/aqb-select-item-ui.model.ts
+++ b/src/app/modules/aqls/models/aqb/aqb-select-item-ui.model.ts
@@ -19,7 +19,6 @@ import { IAqbSelectFieldNode } from 'src/app/shared/models/archetype-query-build
 import { ReferenceModelType } from 'src/app/shared/models/archetype-query-builder/referencemodel-type.enum'
 import { ConnectorNodeType } from 'src/app/shared/models/connector-node-type.enum'
 import { IContainmentTreeNode } from '../containment-tree-node.interface'
-import { IdHelperService } from 'src/app/core/helper/id-helper.service'
 
 export class AqbSelectItemUiModel {
   readonly type = ConnectorNodeType.Aqb_Item
@@ -56,7 +55,11 @@ export class AqbSelectItemUiModel {
       _type: AqbNodeType.SelectField,
       aqlPath: this.aqlPath,
       containmentId: this.archetypeReferenceId,
-      name: this.givenName.length ? this.givenName : 'alias_' + IdHelperService.getSimpleId(),
+      name: this.givenName.length
+        ? this.givenName
+        : this.isComposition
+        ? this.templateId
+        : this.name,
     }
   }
 }

--- a/src/app/modules/aqls/models/aqb/aqb-ui.model.spec.ts
+++ b/src/app/modules/aqls/models/aqb/aqb-ui.model.spec.ts
@@ -26,6 +26,7 @@ describe('AqbUiModel', () => {
     item: {
       archetypeId: 'testArchetypeId1',
       displayName: 'test1',
+      name: 'test1',
     },
   }
 
@@ -34,7 +35,18 @@ describe('AqbUiModel', () => {
     templateId: 'testTemplId2',
     item: {
       displayName: 'test2',
+      name: 'test2',
       parentArchetypeId: 'testArchetypeId2',
+    },
+  }
+
+  const clickEvent3: IAqbSelectClick = {
+    compositionId: 'testCompId3',
+    templateId: 'testTemplId3',
+    item: {
+      displayName: 'test3',
+      name: 'test3',
+      parentArchetypeId: 'testCompId3',
     },
   }
 
@@ -89,7 +101,7 @@ describe('AqbUiModel', () => {
       // Prefill
       model.handleElementSelect(clickEvent1)
       model.handleElementSelect(clickEvent2)
-      model.handleDeletionByComposition(['testCompId1'])
+      model.handleDeletionByCompositionReferenceIds([1])
     })
     it('should delete the composition in the contains', () => {
       expect(model.contains.deleteCompositions).toHaveBeenLastCalledWith([1])
@@ -107,12 +119,29 @@ describe('AqbUiModel', () => {
       // Prefill
       model.handleElementSelect(clickEvent1)
       model.handleElementSelect(clickEvent2)
-      model.handleDeletionByArchetype(['testArchetypeId1', 'notExistingOne'])
+      model.handleDeletionByArchetypeReferenceIds([2, /* not existing -> */ 123456789])
     })
 
     it('should remove the items in the select clause corresponding to the archetypeReferenceId', () => {
       expect(model.select.length).toEqual(1)
       expect(model.select[0].compositionReferenceId).toEqual(3)
+    })
+  })
+
+  describe('When the model gets converted to the api model', () => {
+    beforeEach(() => {
+      jest.spyOn(model.contains, 'deleteCompositions')
+      // Prefill
+      model.handleElementSelect(clickEvent3)
+      model.handleElementSelect(clickEvent3)
+      model.handleElementSelect(clickEvent3)
+    })
+
+    it('should convert with unique aliases', () => {
+      const convertedModel = model.convertToApi()
+      expect(convertedModel.select.statement[0].name).toEqual('test3')
+      expect(convertedModel.select.statement[1].name).toEqual('test3_2')
+      expect(convertedModel.select.statement[2].name).toEqual('test3_3')
     })
   })
 })

--- a/src/app/modules/aqls/models/aqb/aqb-where-group-ui.model.ts
+++ b/src/app/modules/aqls/models/aqb/aqb-where-group-ui.model.ts
@@ -30,7 +30,14 @@ export class AqbWhereGroupUiModel {
   children: PossibleChildren[] = []
   indexInGroup: number | null = null
 
-  constructor() {}
+  constructor(baseGroup = false) {
+    if (baseGroup) {
+      const templateRestrictionGroup = new AqbWhereGroupUiModel()
+      templateRestrictionGroup.logicalOperator = LogicalOperator.Or
+      this.children.push(templateRestrictionGroup)
+      this.children.push(new AqbWhereGroupUiModel())
+    }
+  }
 
   private getOperatorNode(values: PossibleWheres[]): IAqbLogicalOperatorNode<PossibleWheres> {
     return {
@@ -42,11 +49,11 @@ export class AqbWhereGroupUiModel {
 
   private convertToBinaryTree(
     children: PossibleWheres[]
-  ): { result: IAqbLogicalOperatorNode<PossibleWheres>; rr: any } {
+  ): { result: IAqbLogicalOperatorNode<PossibleWheres>; _: any } {
     const initialAndResultingValue = this.getOperatorNode([])
 
     const inputLength = children.length
-    const rr = children.reduce((acc: IAqbLogicalOperatorNode<PossibleWheres>, current, index) => {
+    const _ = children.reduce((acc: IAqbLogicalOperatorNode<PossibleWheres>, current, index) => {
       if (acc.values.length >= 1 && index !== inputLength - 1) {
         const node = this.getOperatorNode([current])
         acc.values.push(node)
@@ -59,7 +66,7 @@ export class AqbWhereGroupUiModel {
 
     return {
       result: initialAndResultingValue,
-      rr,
+      _,
     }
   }
 


### PR DESCRIPTION
**This PR adds:**

- In the SELECT clause each composition has the template name as alias on conversion
- The alias is unique (if not, it is automatically extended)
- There is one composition for each template in the CONTAINS clause
- Each composition is restricted to the corresponding template in the WHERE clause
- When I add one template to the SELECT clause the restriction to the selected template is added to the WHERE clause automatically

**Story-Description:**
As a researcher I want to retrieve the selected data as tables per EHR template, so that I can compare the results.