### PR TITLE
fix(NUM-1613): Fixes compiling of angular playground and icon playground

### DIFF
--- a/src/app/layout/font-awesome-icons.ts
+++ b/src/app/layout/font-awesome-icons.ts
@@ -54,7 +54,7 @@ import {
 
 import { faNewspaper, faCheckCircle, faEye, faHospital } from '@fortawesome/free-regular-svg-icons'
 
-export const FONT_AWESOME_ICONS = [
+export const FONT_AWESOME_SOLID_ICONS = [
   faMicroscope,
   faBars,
   faGlobeEurope,
@@ -68,7 +68,6 @@ export const FONT_AWESOME_ICONS = [
   faTimesCircle,
   faTimes,
   faCheck,
-  faCheckCircle,
   faTrash,
   faAngleRight,
   faEllipsisV,
@@ -76,22 +75,23 @@ export const FONT_AWESOME_ICONS = [
   faUser,
   faTable,
   faExternalLinkAlt,
-  faEye,
   faUserLock,
   faAlignLeft,
   faPlay,
   faPen,
+  faExclamationCircle,
   faBuilding,
   faUserEdit,
-  faNewspaper,
-  faExclamationCircle,
   faFileDownload,
   faCaretSquareUp,
   faArrowsAlt,
   faExclamationTriangle,
   faArrowDown,
-  faHospital,
   faExternalLinkSquareAlt,
   faChartPie,
   faUndo,
 ]
+
+export const FONT_AWESOME_REGULAR_ICONS = [faNewspaper, faCheckCircle, faEye, faHospital]
+
+export const FONT_AWESOME_ICONS = [...FONT_AWESOME_SOLID_ICONS, ...FONT_AWESOME_REGULAR_ICONS]

--- a/src/playground/pg_icons/pg_icons.component.html
+++ b/src/playground/pg_icons/pg_icons.component.html
@@ -18,13 +18,23 @@
   <h1>Icons</h1>
   <div class="icon-list" fxLayout="row wrap" fxLayout.lt-sm="column" fxLayoutAlign="flex-start">
     <section
-      *ngFor="let icon of icons"
+      *ngFor="let icon of solidIcons"
       fxFlex="0 1 calc(33.3% - 32px)"
       fxFlex.lt-md="0 1 calc(50% - 32px)"
       fxFlex.lt-sm="100%"
     >
-      <span class="mat-body-strong">{{ icon }}</span>
+      <span class="mat-body-strong">{{ 'Solid: ' + icon }}</span>
       <fa-icon class="num-fc--a" [icon]="icon" size="lg" [fixedWidth]="true"></fa-icon>
+    </section>
+
+    <section
+      *ngFor="let icon of regularIcons"
+      fxFlex="0 1 calc(33.3% - 32px)"
+      fxFlex.lt-md="0 1 calc(50% - 32px)"
+      fxFlex.lt-sm="100%"
+    >
+      <span class="mat-body-strong">{{ 'Regular: ' + icon }}</span>
+      <fa-icon class="num-fc--a" [icon]="['far', icon]" size="lg" [fixedWidth]="true"></fa-icon>
     </section>
   </div>
 </main>

--- a/src/playground/pg_icons/pg_icons.component.ts
+++ b/src/playground/pg_icons/pg_icons.component.ts
@@ -16,7 +16,10 @@
 
 import { Component } from '@angular/core'
 import { CUSTOM_ICONS } from 'src/app/layout/custom-icons'
-import { FONT_AWESOME_ICONS } from 'src/app/layout/font-awesome-icons'
+import {
+  FONT_AWESOME_REGULAR_ICONS,
+  FONT_AWESOME_SOLID_ICONS,
+} from 'src/app/layout/font-awesome-icons'
 
 @Component({
   selector: 'num-pg-icons',
@@ -24,6 +27,7 @@ import { FONT_AWESOME_ICONS } from 'src/app/layout/font-awesome-icons'
   styleUrls: ['./pg_icons.component.scss'],
 })
 export class PgIconsComponent {
-  icons = [...FONT_AWESOME_ICONS, ...CUSTOM_ICONS].map((icon) => icon.iconName)
+  solidIcons = [...FONT_AWESOME_SOLID_ICONS, ...CUSTOM_ICONS].map((icon) => icon.iconName)
+  regularIcons = [...FONT_AWESOME_REGULAR_ICONS].map((icon) => icon.iconName)
   constructor() {}
 }

--- a/tsconfig.playground.json
+++ b/tsconfig.playground.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "angularCompilerOptions": {
+    "enableIvy": false
+  },
   "compilerOptions": {
     "outDir": "./out-tsc/app",
     "types": []


### PR DESCRIPTION
This PR changes the compiling of the angular playground to not use ivy. This should fix compiling issues. It also organizes the icon library to differ between regular and solid icons to be used in the playground