### PR TITLE
feat(NUM-1639): Renames study to project in all cases expect roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog][Keep a Changelog] and this project adheres to [Semantic Versioning][Semantic Versioning].
+The format is based on [Keep a Changelog][keep a changelog] and this project adheres to [Semantic Versioning][semantic versioning].
 
 ## [Unreleased]
 
@@ -9,6 +10,7 @@ The format is based on [Keep a Changelog][Keep a Changelog] and this project adh
 
 - Role "Manager" that takes over responsibilities from role "Project Lead" for managing AQLs and Phenotypes ([#224])
 - AQL Category management page to create, update or delete categories for AQL queries ([#227])
+- Renaming of all occurrences of the term "study" to "project" in all cases except for roles ([#228])
 
 ---
 
@@ -54,7 +56,7 @@ The format is based on [Keep a Changelog][Keep a Changelog] and this project adh
 ### Added
 
 - Phenotype Overview table: Delete phenotypes ([#183])
-- Phenotype overview table: Filter by users' organization, users' own or all ([#195]) 
+- Phenotype overview table: Filter by users' organization, users' own or all ([#195])
 - AQL overview table: Delete not owned AQLs as super admin ([#185])
 - Project overview table: Delete and archive projects ([#186])
 - Project overview table: Filter for archived project ([#188])
@@ -79,7 +81,7 @@ The format is based on [Keep a Changelog][Keep a Changelog] and this project adh
 
 ### Security
 
-- Links with target _blank: Add rel=noopener to all links ([#184])
+- Links with target \_blank: Add rel=noopener to all links ([#184])
 
 ## [1.0.0] - 2021-03-31
 
@@ -162,13 +164,11 @@ The format is based on [Keep a Changelog][Keep a Changelog] and this project adh
 - Dependency Update lodash-es from 4.17.20 to 4.17.21 ([#136])
 - Dependency Update rxjs from 6.6.3 to 6.6.6 ([#136])
 
-
 ## [0.2.0] - 2021-03-01
 
 ### Added
 
 - Organzation manager - Create and edit Organizations with Organizations Editor ([#125])
-
 
 ## [0.1.0] - 2021-02-25
 
@@ -198,20 +198,22 @@ The format is based on [Keep a Changelog][Keep a Changelog] and this project adh
 - Toast messages for user feedback ([#96])
 - Content Editor - Edit menu items ([#115], [#119])
 - Organization manager - Organizations table ([#117], [#122])
+
 ### Security
 
 - Angular v11.1.1 ([#95])
 
-
 ---
 
 <!-- Links -->
-[Keep a Changelog]: https://keepachangelog.com/
-[Semantic Versioning]: https://semver.org/
+
+[keep a changelog]: https://keepachangelog.com/
+[semantic versioning]: https://semver.org/
 
 <!-- Versions -->
-[Unreleased]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/compare/v1.2.0...HEAD
-[Released]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/tree/master
+
+[unreleased]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/compare/v1.2.0...HEAD
+[released]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/tree/master
 [1.2.0]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/compare/v1.1.0..v1.2.0
 [1.1.0]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/compare/8ad602c9bbe0e6c5b535ebdbd6cc86370e863f34..v1.1.0
 [1.0.0]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/compare/2dc040e5eb792bfffb5959172fe8b40b2ee2f739..8ad602c9bbe0e6c5b535ebdbd6cc86370e863f34
@@ -222,6 +224,7 @@ The format is based on [Keep a Changelog][Keep a Changelog] and this project adh
 [0.1.0]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/compare/137548301f9143282686503e915163dfffe03090..e6babad91dbeb562803ad3a1ec6afa1726e0c09a
 
 <!-- PRs  -->
+
 [#1]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/1
 [#2]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/2
 [#3]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/3
@@ -446,3 +449,4 @@ The format is based on [Keep a Changelog][Keep a Changelog] and this project adh
 [#223]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/223
 [#224]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/224
 [#227]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/227
+[#228]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/228

--- a/src/app/core/services/cohort/cohort.service.spec.ts
+++ b/src/app/core/services/cohort/cohort.service.spec.ts
@@ -38,7 +38,7 @@ describe('CohortService', () => {
   const mockCohort: ICohortApi = {
     id: null,
     name: 'Test Name',
-    studyId: 1, // Should change to projectId once the BE is refactored
+    projectId: 1,
     description: 'Test Description',
     cohortGroup: undefined,
   }

--- a/src/app/core/services/project/project.service.spec.ts
+++ b/src/app/core/services/project/project.service.spec.ts
@@ -43,7 +43,7 @@ import { mockResultSetFlat } from 'src/mocks/data-mocks/result-set-mock'
 
 describe('ProjectService', () => {
   let service: ProjectService
-  const baseUrl = 'localhost/api/study'
+  const baseUrl = 'localhost/api/project'
   let mockProject1Local
   let throttleTime: number
 
@@ -100,7 +100,7 @@ describe('ProjectService', () => {
         .toPromise()
         .then((_) => {})
         .catch((_) => {})
-      expect(httpClient.get).toHaveBeenCalledWith(`localhost/api/study`)
+      expect(httpClient.get).toHaveBeenCalledWith(`localhost/api/project`)
       expect(service.handleError).toHaveBeenCalled()
     })
   })
@@ -111,7 +111,7 @@ describe('ProjectService', () => {
       service.get(1).subscribe((result) => {
         expect(result).toEqual(mockProject1Local)
       })
-      expect(httpClient.get).toHaveBeenCalledWith(`localhost/api/study/${1}`)
+      expect(httpClient.get).toHaveBeenCalledWith(`localhost/api/project/${1}`)
     })
     it(`should call the api - with error`, () => {
       jest.spyOn(service, 'handleError')
@@ -121,7 +121,7 @@ describe('ProjectService', () => {
         .toPromise()
         .then((_) => {})
         .catch((_) => {})
-      expect(httpClient.get).toHaveBeenCalledWith(`localhost/api/study/${1}`)
+      expect(httpClient.get).toHaveBeenCalledWith(`localhost/api/project/${1}`)
       expect(service.handleError).toHaveBeenCalled()
     })
   })
@@ -132,7 +132,7 @@ describe('ProjectService', () => {
       service.create(mockProject1Local).subscribe((result) => {
         expect(result).toEqual(mockProject1Local)
       })
-      expect(httpClient.post).toHaveBeenCalledWith(`localhost/api/study`, mockProject1Local)
+      expect(httpClient.post).toHaveBeenCalledWith(`localhost/api/project`, mockProject1Local)
     })
     it(`should call the api - with error`, () => {
       jest.spyOn(service, 'handleError')
@@ -142,7 +142,7 @@ describe('ProjectService', () => {
         .toPromise()
         .then((_) => {})
         .catch((_) => {})
-      expect(httpClient.post).toHaveBeenCalledWith(`localhost/api/study`, mockProject1Local)
+      expect(httpClient.post).toHaveBeenCalledWith(`localhost/api/project`, mockProject1Local)
       expect(service.handleError).toHaveBeenCalled()
     })
   })
@@ -153,7 +153,7 @@ describe('ProjectService', () => {
       service.update(mockProject1Local, 1).subscribe((result) => {
         expect(result).toEqual(mockProject1Local)
       })
-      expect(httpClient.put).toHaveBeenCalledWith(`localhost/api/study/${1}`, mockProject1Local)
+      expect(httpClient.put).toHaveBeenCalledWith(`localhost/api/project/${1}`, mockProject1Local)
     })
     it(`should call the api - with error`, () => {
       jest.spyOn(service, 'handleError')
@@ -163,7 +163,7 @@ describe('ProjectService', () => {
         .toPromise()
         .then((_) => {})
         .catch((_) => {})
-      expect(httpClient.put).toHaveBeenCalledWith(`localhost/api/study/${1}`, mockProject1Local)
+      expect(httpClient.put).toHaveBeenCalledWith(`localhost/api/project/${1}`, mockProject1Local)
       expect(service.handleError).toHaveBeenCalled()
     })
   })
@@ -172,7 +172,7 @@ describe('ProjectService', () => {
     it(`should call the api - with success`, () => {
       jest.spyOn(httpClient, 'delete').mockImplementation(() => of(mockProject1Local))
       service.delete(1).subscribe()
-      expect(httpClient.delete).toHaveBeenCalledWith(`localhost/api/study/${1}`)
+      expect(httpClient.delete).toHaveBeenCalledWith(`localhost/api/project/${1}`)
     })
     it(`should call the api - with error`, () => {
       jest.spyOn(service, 'handleError')
@@ -182,7 +182,7 @@ describe('ProjectService', () => {
         .toPromise()
         .then((_) => {})
         .catch((_) => {})
-      expect(httpClient.delete).toHaveBeenCalledWith(`localhost/api/study/${1}`)
+      expect(httpClient.delete).toHaveBeenCalledWith(`localhost/api/project/${1}`)
       expect(service.handleError).toHaveBeenCalled()
     })
   })
@@ -193,7 +193,7 @@ describe('ProjectService', () => {
       service.executeAdHocAql('query', 1).subscribe((result) => {
         expect(result).toEqual([mockResultSetFlat])
       })
-      expect(httpClient.post).toHaveBeenCalledWith(`localhost/api/study/${1}/execute`, {
+      expect(httpClient.post).toHaveBeenCalledWith(`localhost/api/project/${1}/execute`, {
         query: 'query',
       })
     })
@@ -205,7 +205,7 @@ describe('ProjectService', () => {
         .toPromise()
         .then((_) => {})
         .catch((_) => {})
-      expect(httpClient.post).toHaveBeenCalledWith(`localhost/api/study/${1}/execute`, {
+      expect(httpClient.post).toHaveBeenCalledWith(`localhost/api/project/${1}/execute`, {
         query: 'query',
       })
       expect(service.handleError).toHaveBeenCalled()

--- a/src/app/core/services/project/project.service.ts
+++ b/src/app/core/services/project/project.service.ts
@@ -61,8 +61,7 @@ export class ProjectService {
     appConfig: AppConfigService,
     private profileService: ProfileService
   ) {
-    // TODO we need to change the api from 'study' to 'project'
-    this.baseUrl = `${appConfig.config.api.baseUrl}/study`
+    this.baseUrl = `${appConfig.config.api.baseUrl}/project`
     this.profileService.userProfileObservable$.subscribe((user) => (this.user = user))
 
     this.filterConfigObservable$

--- a/src/app/modules/data-explorer/components/data-explorer/data-explorer.component.html
+++ b/src/app/modules/data-explorer/components/data-explorer/data-explorer.component.html
@@ -23,27 +23,27 @@
       [form]="projectForm"
       [isDisabled]="isGeneralInfoDisabled"
       [generalInfoData]="generalInfoData"
-      data-test="study-editor__general-info"
+      data-test="project-editor__general-info"
     ></num-project-editor-general-info>
 
     <num-project-editor-templates
       [(templates)]="project.templates"
       [isDisabled]="isTemplatesDisabled"
-      data-test="study-editor__templates"
+      data-test="project-editor__templates"
     ></num-project-editor-templates>
 
     <num-project-editor-connector
       [cohortNode]="cohortGroup"
       [isLoadingComplete]="isCohortsFetched"
       [isDisabled]="isConnectorDisabled"
-      data-test="study-editor__connector"
+      data-test="project-editor__connector"
     ></num-project-editor-connector>
 
     <num-project-editor-researchers
       [isLoadingComplete]="isResearchersFetched"
       [(researchers)]="project.researchers"
       [isDisabled]="isResearchersDisabled"
-      data-test="study-editor__researchers"
+      data-test="project-editor__researchers"
     ></num-project-editor-researchers>
   </mat-accordion>
 

--- a/src/app/modules/projects/components/dialog-confirm-project-approval/dialog-confirm-project-approval.component.html
+++ b/src/app/modules/projects/components/dialog-confirm-project-approval/dialog-confirm-project-approval.component.html
@@ -22,7 +22,7 @@
       id="isChecked"
       color="accent"
       formControlName="check"
-      data-test="dialog-confirm-study__approval__ethical-approval-checkbox"
+      data-test="dialog-confirm-project__approval__ethical-approval-checkbox"
       >{{ 'FORM.ETHICAL_APPROVAL_CHECKBOX' | translate }}</mat-checkbox
     >
   </form>
@@ -31,7 +31,7 @@
     <num-button
       type="secondary"
       (singleClick)="handleDialogCancel()"
-      data-test="dialog-confirm-study__approval__cancel-button"
+      data-test="dialog-confirm-project__approval__cancel-button"
       >{{ 'BUTTON.CANCEL' | translate }}</num-button
     >
 
@@ -40,7 +40,7 @@
       type="primary"
       (singleClick)="handleDialogConfirm()"
       [isDisabled]="form.invalid"
-      data-test="dialog-confirm-study__approval__approval-button"
+      data-test="dialog-confirm-project__approval__approval-button"
       >{{ 'BUTTON.PROJECT_APPROVAL_APPROVE' | translate }}</num-button
     >
   </div>

--- a/src/app/modules/projects/components/project-editor-approval/project-editor-approval.component.html
+++ b/src/app/modules/projects/components/project-editor-approval/project-editor-approval.component.html
@@ -25,12 +25,12 @@
       fxLayout="column"
       fxLayoutGap="10px"
       formControlName="decision"
-      data-test="study-editor__approval__radio-group"
+      data-test="project-editor__approval__radio-group"
     >
       <mat-radio-button
         *ngFor="let approvalOption of approvalOptions"
         [value]="approvalOption"
-        [attr.data-test]="'study-editor__approval__' + approvalOption + '-radio-option'"
+        [attr.data-test]="'project-editor__approval__' + approvalOption + '-radio-option'"
       >
         {{ 'PROJECT.REVIEW.' + approvalOption | translate }}</mat-radio-button
       >

--- a/src/app/modules/projects/components/project-editor-buttons/project-editor-buttons.component.html
+++ b/src/app/modules/projects/components/project-editor-buttons/project-editor-buttons.component.html
@@ -21,7 +21,7 @@
       id="back-button"
       type="secondary"
       (singleClick)="cancel.emit()"
-      data-test="study-editor__buttons__back-button"
+      data-test="project-editor__buttons__back-button"
       >{{
         (editorMode === possibleModes.PREVIEW ? 'BUTTON.BACK' : 'BUTTON.CANCEL') | translate
       }}</num-button
@@ -62,7 +62,7 @@
     "
     (singleClick)="saveResearchers.emit()"
     [isDisabled]="!isFormValid || !isResearchersDefined || !isTemplatesDefined || !isCohortDefined"
-    data-test="study-editor__buttons__primary-save-button"
+    data-test="project-editor__buttons__primary-save-button"
     >{{ 'BUTTON.SAVE' | translate }}</num-button
   >
   <ng-template #fullEdit>
@@ -74,7 +74,7 @@
         (projectStatus !== possibleStatus.Draft && projectStatus !== possibleStatus.ChangeRequest)
       "
       (singleClick)="saveAll.emit()"
-      data-test="study-editor__buttons__secondary-save-button"
+      data-test="project-editor__buttons__secondary-save-button"
       >{{ 'BUTTON.SAVE' | translate }}</num-button
     >
     <num-button
@@ -88,7 +88,7 @@
         !isCohortDefined ||
         (projectStatus !== possibleStatus.Draft && projectStatus !== possibleStatus.ChangeRequest)
       "
-      data-test="study-editor__buttons__request-approval-button"
+      data-test="project-editor__buttons__request-approval-button"
       >{{ 'BUTTON.REQUEST_APPROVAL' | translate }}</num-button
     >
   </ng-template>
@@ -100,7 +100,7 @@
     type="primary"
     (singleClick)="saveAsApprovalReply.emit()"
     [isDisabled]="approverForm.invalid || projectStatus !== possibleStatus.Reviewing"
-    data-test="study-editor__buttons__approval-reply-button"
+    data-test="project-editor__buttons__approval-reply-button"
     >{{ 'BUTTON.PROJECT_APPROVAL_' + approvalDecision | translate }}</num-button
   >
 </ng-template>
@@ -117,7 +117,7 @@
         projectStatus === possibleStatus.Approved
       )
     "
-    data-test="study-editor__buttons__start-edit-button"
+    data-test="project-editor__buttons__start-edit-button"
     >{{
       (projectStatus === possibleStatus.Approved ? 'BUTTON.EDIT_RESEARCHERS' : 'BUTTON.EDIT')
         | translate

--- a/src/app/modules/projects/components/project-editor-comments/project-editor-comments.component.html
+++ b/src/app/modules/projects/components/project-editor-comments/project-editor-comments.component.html
@@ -24,7 +24,7 @@
       id="older-comments-toggle"
       *ngIf="comments.length > 2"
       (click)="toggleCommentLimit()"
-      data-test="study-editor__comments__older-comments-button"
+      data-test="project-editor__comments__older-comments-button"
     >
       {{ (commentLimit ? 'SHOW_OLDER_POSTS' : 'SHOW_LESS') | translate }}
     </a>
@@ -66,7 +66,7 @@
         style="resize: none"
         aria-labelledby="desc-label"
         rows="6"
-        data-test="study-editor__comments__leave-comment-input"
+        data-test="project-editor__comments__leave-comment-input"
       ></textarea>
     </mat-form-field>
   </form>
@@ -76,7 +76,7 @@
       (singleClick)="postComment.emit()"
       [isDisabled]="form.invalid"
       type="primary"
-      data-test="study-editor__comments__send-comment-button"
+      data-test="project-editor__comments__send-comment-button"
       >{{ 'BUTTON.SEND_COMMENT' | translate }}</num-button
     >
   </section>

--- a/src/app/modules/projects/components/project-editor-connector-group/project-editor-connector-group.component.html
+++ b/src/app/modules/projects/components/project-editor-connector-group/project-editor-connector-group.component.html
@@ -29,12 +29,12 @@
       [attr.aria-label]="'LOGICAL_OPERATOR' | translate"
       [(value)]="cohortGroup.logicalOperator"
       [disabled]="cohortGroup.children.length <= 1 || isDisabled"
-      data-test="study-editor__connector__group__logical-operator__selector"
+      data-test="project-editor__connector__group__logical-operator__selector"
     >
       <mat-option
         *ngFor="let operator of logicalOperatorArray"
         [value]="operator"
-        [attr.data-test]="'study-editor__connector__group__logical-operator__' + operator"
+        [attr.data-test]="'project-editor__connector__group__logical-operator__' + operator"
       >
         {{ operator }}
       </mat-option>
@@ -47,7 +47,7 @@
     labelPosition="before"
     [(ngModel)]="cohortGroup.isNegated"
     [disabled]="isDisabled"
-    data-test="study-editor__connector__group__negation-toggle"
+    data-test="project-editor__connector__group__negation-toggle"
     >Negation</mat-slide-toggle
   >
 </section>
@@ -63,7 +63,7 @@
     [isDisabled]="isDisabled"
     (delete)="deleteChild($event)"
     fxFlex="100%"
-    data-test="study-editor__connector__group"
+    data-test="project-editor__connector__group"
   ></num-project-editor-connector-group>
 
   <num-project-editor-connector-phenotype
@@ -80,7 +80,7 @@
     role="listitem"
     fxLayout="row"
     fxLayoutAlign="space-between center"
-    data-test="study-editor__connector__phenotype"
+    data-test="project-editor__connector__phenotype"
   ></num-project-editor-connector-phenotype>
 </section>
 
@@ -90,7 +90,7 @@
     type="primary"
     icon="plus"
     (singleClick)="addPhenotype()"
-    data-test="study-editor__connector__group__add-phenotype-button"
+    data-test="project-editor__connector__group__add-phenotype-button"
     >{{ 'BUTTON.ADD_PHENOTYPE' | translate }}</num-button
   >
   <num-button
@@ -98,7 +98,7 @@
     type="secondary"
     icon="plus"
     (singleClick)="addGroup()"
-    data-test="study-editor__connector__group__add-group-button"
+    data-test="project-editor__connector__group__add-group-button"
     >{{ 'BUTTON.ADD_GROUP' | translate }}</num-button
   >
 
@@ -109,7 +109,7 @@
     *ngIf="groupType === connectorGroupType.Sub"
     type="basic"
     (singleClick)="deleteSelf()"
-    data-test="study-editor__connector__group__delete-group-button"
+    data-test="project-editor__connector__group__delete-group-button"
     >{{ 'BUTTON.DELETE_GROUP' | translate }}</num-button
   >
 </section>

--- a/src/app/modules/projects/components/project-editor-connector-phenotype/project-editor-connector-phenotype.component.html
+++ b/src/app/modules/projects/components/project-editor-connector-phenotype/project-editor-connector-phenotype.component.html
@@ -24,7 +24,7 @@
     size="lg"
     [fixedWidth]="true"
     (click)="handleClick()"
-    data-test="study-editor__connector__phenotype__settings-button"
+    data-test="project-editor__connector__phenotype__settings-button"
   ></fa-icon>
 </ng-container>
 

--- a/src/app/modules/projects/components/project-editor-connector/project-editor-connector.component.html
+++ b/src/app/modules/projects/components/project-editor-connector/project-editor-connector.component.html
@@ -15,7 +15,7 @@
 -->
 
 <mat-expansion-panel>
-  <mat-expansion-panel-header data-test="study-editor__connector__define-cohort-button">
+  <mat-expansion-panel-header data-test="project-editor__connector__define-cohort-button">
     <mat-panel-title>
       <h3 class="accordion">
         <fa-icon
@@ -48,7 +48,7 @@
       [parentGroupIndex]="null"
       [isDisabled]="isDisabled"
       fxFlex="100%"
-      data-test="study-editor__connector__group"
+      data-test="project-editor__connector__group"
     ></num-project-editor-connector-group>
 
     <!-- NUM-1450: Determine Hits in Data Explorer is not shown for Release 1.0 -->

--- a/src/app/modules/projects/components/project-editor-general-info-categories-input/project-editor-general-info-categories-input.component.html
+++ b/src/app/modules/projects/components/project-editor-general-info-categories-input/project-editor-general-info-categories-input.component.html
@@ -19,20 +19,20 @@
   <mat-chip-list
     #categoryChipList
     aria-label="Category selection"
-    data-test="study-editor__general-info__categories-chip-list"
+    data-test="project-editor__general-info__categories-chip-list"
   >
     <mat-chip
       *ngFor="let category of categories; let i = index"
       (removed)="removeCategory(i)"
       [value]="category"
       class="chip-primary"
-      data-test="study-editor__general-info__category-chip"
+      data-test="project-editor__general-info__category-chip"
     >
       <span>{{ 'PROJECT.CATEGORIES.' + category | translate }}</span>
       <fa-icon
         icon="times-circle"
         class="chip__remove-icon"
-        data-test="study-editor__general-info__categories-remove-category-button"
+        data-test="project-editor__general-info__categories-remove-category-button"
         matChipRemove
       ></fa-icon>
     </mat-chip>
@@ -52,19 +52,19 @@
     #categoryAutocomplete="matAutocomplete"
     (optionSelected)="addCategory($event, trigger)"
     autoActiveFirstOption
-    data-test="study-editor__general-info__categories-autocomplete"
+    data-test="project-editor__general-info__categories-autocomplete"
   >
     <mat-option
       *ngFor="let category of filteredCategories | async"
       [value]="category"
-      data-test="study-editor__general-info__category-option"
+      data-test="project-editor__general-info__category-option"
     >
       {{ 'PROJECT.CATEGORIES.' + category | translate }}
     </mat-option>
     <mat-option
       *ngIf="isNoResults"
       disabled
-      data-test="study-editor__general-info__category-option__no-results"
+      data-test="project-editor__general-info__category-option__no-results"
     >
       {{ 'PROJECT.CATEGORIES_NO_RESULTS' | translate }}
     </mat-option>

--- a/src/app/modules/projects/components/project-editor-general-info-keywords-input/project-editor-general-info-keywords-input.component.html
+++ b/src/app/modules/projects/components/project-editor-general-info-keywords-input/project-editor-general-info-keywords-input.component.html
@@ -19,19 +19,19 @@
   <mat-chip-list
     #keywordsChipList
     aria-label="Keywords selection"
-    data-test="study-editor__general-info__keywords-chip-list"
+    data-test="project-editor__general-info__keywords-chip-list"
   >
     <mat-chip
       *ngFor="let keyword of keywords; let i = index"
       (removed)="removeKeyword(i)"
       class="chip-primary"
-      data-test="study-editor__general-info__keywords-chip-item"
+      data-test="project-editor__general-info__keywords-chip-item"
     >
       <span>{{ keyword }}</span>
       <fa-icon
         icon="times-circle"
         class="chip__remove-icon"
-        data-test="study-editor__general-info__keywords-remove-keyword-button"
+        data-test="project-editor__general-info__keywords-remove-keyword-button"
         matChipRemove
       ></fa-icon>
     </mat-chip>
@@ -42,7 +42,7 @@
       matChipInputAddOnBlur
       (matChipInputTokenEnd)="addKeyword($event)"
       autocomplete="off"
-      data-test="study-editor__general-info__keywords-input"
+      data-test="project-editor__general-info__keywords-input"
     />
   </mat-chip-list>
 </mat-form-field>

--- a/src/app/modules/projects/components/project-editor-general-info/project-editor-general-info.component.html
+++ b/src/app/modules/projects/components/project-editor-general-info/project-editor-general-info.component.html
@@ -39,7 +39,7 @@
           matInput
           [placeholder]="'PROJECT.TITLE_PLACEHOLDER' | translate"
           aria-labelledby="title-label"
-          data-test="study-editor__general-info__title-input"
+          data-test="project-editor__general-info__title-input"
         />
       </mat-form-field>
 
@@ -53,7 +53,7 @@
           style="resize: none"
           aria-labelledby="desc-label"
           rows="10"
-          data-test="study-editor__general-info__description-input"
+          data-test="project-editor__general-info__description-input"
         ></textarea>
       </mat-form-field>
 
@@ -81,7 +81,7 @@
           style="resize: none"
           aria-labelledby="goal-label"
           rows="10"
-          data-test="study-editor__general-info__goal-input"
+          data-test="project-editor__general-info__goal-input"
         ></textarea>
       </mat-form-field>
 
@@ -97,7 +97,7 @@
             style="resize: none"
             aria-labelledby="label-firstHypotheses"
             rows="10"
-            data-test="study-editor__general-info__first-hypotheses-input"
+            data-test="project-editor__general-info__first-hypotheses-input"
           ></textarea>
         </mat-form-field>
 
@@ -112,7 +112,7 @@
             style="resize: none"
             aria-labelledby="label-secondHypotheses"
             rows="10"
-            data-test="study-editor__general-info__second-hypotheses-input"
+            data-test="project-editor__general-info__second-hypotheses-input"
           ></textarea>
         </mat-form-field>
       </section>
@@ -133,12 +133,12 @@
             matInput
             [matDatepicker]="startDate"
             (focus)="startDate.open()"
-            data-test="study-editor__general-info__start-date-input"
+            data-test="project-editor__general-info__start-date-input"
           />
           <mat-datepicker-toggle
             matSuffix
             [for]="startDate"
-            data-test="study-editor__general-info__start-date-toggle"
+            data-test="project-editor__general-info__start-date-toggle"
           ></mat-datepicker-toggle>
           <mat-datepicker #startDate></mat-datepicker>
         </mat-form-field>
@@ -150,12 +150,12 @@
             matInput
             [matDatepicker]="endDate"
             (focus)="endDate.open()"
-            data-test="study-editor__general-info__end-date-input"
+            data-test="project-editor__general-info__end-date-input"
           />
           <mat-datepicker-toggle
             matSuffix
             [for]="endDate"
-            data-test="study-editor__general-info__end-date-toggle"
+            data-test="project-editor__general-info__end-date-toggle"
           ></mat-datepicker-toggle>
           <mat-datepicker #endDate></mat-datepicker>
         </mat-form-field>
@@ -165,7 +165,7 @@
         <p class="mat-display-4 num-margin-b-10">{{ 'FORM.FINANCED' | translate }}</p>
         <mat-slide-toggle
           formControlName="financed"
-          data-test="study-editor__general-info__financed-toggle"
+          data-test="project-editor__general-info__financed-toggle"
           >{{ 'FORM.FINANCED_BY_PRIVATE' | translate }}</mat-slide-toggle
         >
       </section>

--- a/src/app/modules/projects/components/project-editor-researchers/project-editor-researchers.component.html
+++ b/src/app/modules/projects/components/project-editor-researchers/project-editor-researchers.component.html
@@ -59,7 +59,7 @@
                 class="researchers-list_item-delete"
                 [disabled]="isDisabled"
                 (click)="deleteResearcher(element.id)"
-                data-test="study-editor__researchers__delete-researcher-button"
+                data-test="project-editor__researchers__delete-researcher-button"
               >
                 <fa-icon icon="trash" size="lg" [fixedWidth]="true"></fa-icon>
               </button>
@@ -81,7 +81,7 @@
       icon="plus"
       [isDisabled]="isDisabled"
       (singleClick)="addResearchers()"
-      data-test="study-editor__researchers__add-researchers-button"
+      data-test="project-editor__researchers__add-researchers-button"
     >
       {{ 'BUTTON.ADD_RESEARCHERS' | translate }}
     </num-button>

--- a/src/app/modules/projects/components/project-editor-templates/project-editor-templates.component.html
+++ b/src/app/modules/projects/components/project-editor-templates/project-editor-templates.component.html
@@ -38,7 +38,7 @@
     <num-add-template-selected-table
       [(selectedTemplates)]="templates"
       [isDisabled]="isDisabled"
-      data-test="study-editor__templates__add-template-table"
+      data-test="project-editor__templates__add-template-table"
     ></num-add-template-selected-table>
 
     <num-button
@@ -46,7 +46,7 @@
       icon="plus"
       [isDisabled]="isDisabled"
       (singleClick)="addTemplate()"
-      data-test="study-editor__templates__add-template-button"
+      data-test="project-editor__templates__add-template-button"
       >{{ 'BUTTON.ADD_TEMPLATE' | translate }}</num-button
     >
   </section>

--- a/src/app/modules/projects/components/project-editor/project-editor.component.html
+++ b/src/app/modules/projects/components/project-editor/project-editor.component.html
@@ -25,13 +25,13 @@
       [form]="projectForm"
       [isDisabled]="isGeneralInfoDisabled"
       [generalInfoData]="generalInfoData"
-      data-test="study-editor__general-info"
+      data-test="project-editor__general-info"
     ></num-project-editor-general-info>
 
     <num-project-editor-templates
       [(templates)]="project.templates"
       [isDisabled]="isTemplatesDisabled"
-      data-test="study-editor__templates"
+      data-test="project-editor__templates"
     ></num-project-editor-templates>
 
     <num-project-editor-connector
@@ -40,14 +40,14 @@
       [isDisabled]="isConnectorDisabled"
       [determineHitsContent]="determineHitsContent"
       (determineHitsClicked)="determineHits()"
-      data-test="study-editor__connector__group"
+      data-test="project-editor__connector__group"
     ></num-project-editor-connector>
 
     <num-project-editor-researchers
       [isLoadingComplete]="isResearchersFetched"
       [(researchers)]="project.researchers"
       [isDisabled]="isResearchersDisabled"
-      data-test="study-editor__researchers"
+      data-test="project-editor__researchers"
     ></num-project-editor-researchers>
   </mat-accordion>
 
@@ -57,13 +57,13 @@
     [comments]="projectComments"
     [form]="commentForm"
     (postComment)="postComment()"
-    data-test="study-editor__comments"
+    data-test="project-editor__comments"
   ></num-project-editor-comments>
 
   <num-project-editor-approval
     *ngIf="mode === possibleModes.REVIEW"
     [form]="approverForm"
-    data-test="study-editor__approval"
+    data-test="project-editor__approval"
   ></num-project-editor-approval>
 
   <num-project-editor-buttons
@@ -80,6 +80,6 @@
     (saveAsApprovalReply)="saveAsApprovalReply()"
     (startEdit)="startEdit()"
     (cancel)="cancel()"
-    data-test="study-editor__buttons"
+    data-test="project-editor__buttons"
   ></num-project-editor-buttons>
 </section>

--- a/src/app/modules/projects/components/project-editor/project-editor.component.ts
+++ b/src/app/modules/projects/components/project-editor/project-editor.component.ts
@@ -205,7 +205,7 @@ export class ProjectEditorComponent implements OnInit, OnDestroy {
       cohortGroup,
       id: project.cohortId || null,
       name: project.name,
-      studyId: project.id, // Should change to projectId once the BE is refactored
+      projectId: project.id,
       description: project.description,
     }
 
@@ -244,7 +244,7 @@ export class ProjectEditorComponent implements OnInit, OnDestroy {
       this.project.id = projectResult.id
 
       if (cohort.cohortGroup) {
-        cohort.studyId = projectResult.id
+        cohort.projectId = projectResult.id
         const cohortResult = await this.saveCohort(cohort)
         this.project.cohortId = cohortResult.id
       }

--- a/src/app/shared/models/project/cohort-api.interface.ts
+++ b/src/app/shared/models/project/cohort-api.interface.ts
@@ -21,5 +21,5 @@ export interface ICohortApi {
   description?: string
   id: number | null
   name: string
-  studyId: number // Should change to projectId once the BE is refactored
+  projectId: number
 }

--- a/src/app/shared/models/project/project-comment.interface.ts
+++ b/src/app/shared/models/project/project-comment.interface.ts
@@ -20,6 +20,6 @@ export interface IProjectComment {
   author: IUser
   createDate: string
   id: number
-  studyId: number
+  projectId: number
   text: string
 }

--- a/src/mocks/data-mocks/cohorts.mock.ts
+++ b/src/mocks/data-mocks/cohorts.mock.ts
@@ -22,7 +22,7 @@ export const mockCohort1: ICohortApi = {
   id: 1,
   name: 'Cohort 1',
   description: 'Test',
-  studyId: 1, // Should change to projectId once the BE is refactored
+  projectId: 1,
   cohortGroup: {
     id: 2,
     operator: LogicalOperator.And,

--- a/src/mocks/data-mocks/project-comments.mock.ts
+++ b/src/mocks/data-mocks/project-comments.mock.ts
@@ -20,7 +20,7 @@ import { mockUser } from './admin.mock'
 export const projectCommentMock1: IProjectComment = {
   text: 'This is mock no. 1',
   id: 1,
-  studyId: 1,
+  projectId: 1,
   createDate: '2021-01-18T17:15:39.848884+01:00',
   author: mockUser,
 }
@@ -28,7 +28,7 @@ export const projectCommentMock1: IProjectComment = {
 export const projectCommentMock2: IProjectComment = {
   text: 'This is mock no. 1',
   id: 2,
-  studyId: 1,
+  projectId: 1,
   createDate: '2021-01-18T17:15:39.848884+01:00',
   author: mockUser,
 }


### PR DESCRIPTION
This PR renames all occurrences of the word **study** to **project** in all cases except for roles

**Story-Description:**
As a project lead I want to edit operators and parameters in a stored project, so that I can react on a change request