### PR TITLE
fix(NUM-1688): Edit researchers no longer saves the cohort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog][keep a changelog] and this project adh
 - Refactoring of the Cohort-Builder ([#233])
 - Removale of phenotype-concept ([#233])
 - Refactoring of aql-parameter inputs ([#234])
+- Editing researchers in the project editor no longer saves the cohort ([#247])
 
 ---
 
@@ -480,3 +481,4 @@ The format is based on [Keep a Changelog][keep a changelog] and this project adh
 [#242]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/242
 [#243]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/243
 [#245]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/245
+[#247]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/247

--- a/src/app/modules/projects/components/project-editor/project-editor.component.ts
+++ b/src/app/modules/projects/components/project-editor/project-editor.component.ts
@@ -237,13 +237,13 @@ export class ProjectEditorComponent implements OnInit, OnDestroy {
     this.router.navigate(['projects', this.project.id, 'editor'], { queryParams })
   }
 
-  async save(): Promise<void> {
+  async save(withCohort = true): Promise<void> {
     const { project, cohort } = this.getProjectForApi()
     try {
       const projectResult = await this.saveProject(project)
       this.project.id = projectResult.id
 
-      if (cohort.cohortGroup) {
+      if (withCohort && cohort.cohortGroup) {
         cohort.projectId = projectResult.id
         const cohortResult = await this.saveCohort(cohort)
         this.project.cohortId = cohortResult.id
@@ -277,7 +277,7 @@ export class ProjectEditorComponent implements OnInit, OnDestroy {
   }
 
   saveResearchers(): void {
-    this.save()
+    this.save(false)
   }
 
   saveAsApprovalReply(): void {


### PR DESCRIPTION
This PR fixes the issue that the cohort was saved when editing the researchers of a project