### PR TITLE
Hotfix/num 1690 safari regex

### DIFF
--- a/src/app/shared/models/aql/aql-ui.model.ts
+++ b/src/app/shared/models/aql/aql-ui.model.ts
@@ -82,18 +82,18 @@ export class AqlUiModel implements ConnectorMainNodeUi<ICohortGroupApi> {
     })
 
     this.parameters.forEach((parameter) => {
-      const parameterPathRegex = new RegExp(`\\S+\\s+\\S+\\s+\\${parameter.nameWithDollar}`, 'gmi')
+      const parameterPathRegex = new RegExp('\\S+\\s+\\S+\\s+\\' + parameter.nameWithDollar, 'gmi')
       const fullParameterPath = this.query.match(parameterPathRegex)[0]
       const fullParameterPathSplitted = fullParameterPath.split(' ')
       const archetypeReferenceId = fullParameterPathSplitted[0].match(/\w+/)[0]
-      const archetypeIdRegex = new RegExp(`(?<=${archetypeReferenceId}\\[)(.+?)(?=\s*])`)
+      const archetypeIdRegex = new RegExp(archetypeReferenceId + '\\[(.+?)(?=s*])')
 
       parameter.operator =
         fullParameterPathSplitted[1] in AqlParameterOperator
           ? (fullParameterPathSplitted[1] as AqlParameterOperator)
           : AqlParameterOperator['!=']
       parameter.path = fullParameterPathSplitted[0].split(archetypeReferenceId)[1]
-      parameter.archetypeId = this.query.match(archetypeIdRegex)[0]
+      parameter.archetypeId = this.query.match(archetypeIdRegex)[0].split('[')[1]
 
       const pathWithInjectedPlaceholder = fullParameterPath
         .replace(parameter.nameWithDollar, parameter.nameWithDollar + this.NAME_SUFFIX)


### PR DESCRIPTION
This PR fixes the issue, that safari was not able to parse the archetype id for parameters