### PR TITLE
fix(NUM-1693): Adds translation string for clinical models

### DIFF
--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -144,6 +144,7 @@
   "HITS": "Treffer",
   "AVAILABLE_PROJECTS": "Verfügbare Projekte",
   "BUILD_QUERY": "Abfrage erstellen",
+  "AVAILABLE_EHR_TEMPLATES": "Verfügbare klinische Modelle",
   "SELECT_EHR_TEMPLATE": "Klinische Modelle auswählen",
   "SELECTED_EHR_TEMPLATES": "Ausgewählte klinische Modelle",
   "NO_SELECTED_EHR_TEMPLATE": "Noch keine Vorlage ausgewählt",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -143,6 +143,7 @@
   "HITS": "Hits",
   "AVAILABLE_PROJECTS": "Available Projects",
   "BUILD_QUERY": "Build the Query",
+  "AVAILABLE_EHR_TEMPLATES": "Available Clinical Models",
   "SELECT_EHR_TEMPLATE": "Select Clinical Models",
   "SELECTED_EHR_TEMPLATES": "Selected Clinical Models",
   "NO_SELECTED_EHR_TEMPLATE": "No Clinical Models selected yet",


### PR DESCRIPTION
This PR adds the missing translation string for heading of the dialog to select clinical models