### PR TITLE
fix(NUM-1711): Displays invalid for invalid templates

### DIFF
--- a/src/app/modules/search/components/data-filter-templates/data-filter-templates.component.html
+++ b/src/app/modules/search/components/data-filter-templates/data-filter-templates.component.html
@@ -53,7 +53,11 @@
 
           <span *ngIf="!isHitCounterLoading; else hits_loading">
             {{
-              hitCounter[template.templateId] !== undefined ? hitCounter[template.templateId] : ''
+              hitCounter[template.templateId] !== undefined
+                ? hitCounter[template.templateId] !== -1
+                  ? hitCounter[template.templateId]
+                  : 'Invalid'
+                : ''
             }}</span
           >
         </div>


### PR DESCRIPTION
This PR will add that invalid templates are flagged with 'Invalid' once the backend respond with -1