### PR TITLE
fix(NUM-1712) Prevent multiple get aql requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -184,6 +184,40 @@
         "node": ">= 10.13.0",
         "npm": "^6.11.0 || ^7.5.6",
         "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler-cli": "^11.0.0 || ^11.2.0-next",
+        "@angular/localize": "^11.0.0 || ^11.2.0-next",
+        "@angular/service-worker": "^11.0.0 || ^11.2.0-next",
+        "karma": "^5.2.0 || ^6.0.0",
+        "ng-packagr": "^11.0.0 || ^11.2.0-next",
+        "protractor": "^7.0.0",
+        "tailwindcss": "^2.0.0",
+        "tslint": "^6.1.0",
+        "typescript": "~4.0.0 || ~4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@angular/localize": {
+          "optional": true
+        },
+        "@angular/service-worker": {
+          "optional": true
+        },
+        "karma": {
+          "optional": true
+        },
+        "ng-packagr": {
+          "optional": true
+        },
+        "protractor": {
+          "optional": true
+        },
+        "tailwindcss": {
+          "optional": true
+        },
+        "tslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@babel/core": {
@@ -210,6 +244,10 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@babel/core/node_modules/semver": {
@@ -669,6 +707,10 @@
         "node": ">= 10.13.0",
         "npm": "^6.11.0 || ^7.5.6",
         "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.6.0",
+        "webpack-dev-server": "^3.1.4"
       }
     },
     "node_modules/@angular-devkit/build-webpack/node_modules/rxjs": {
@@ -717,6 +759,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@angular-devkit/core/node_modules/rxjs": {
@@ -781,6 +827,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/ansi-regex": {
@@ -802,6 +852,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/chalk": {
@@ -815,6 +868,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/cli-spinners": {
@@ -824,6 +880,9 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/color-convert": {
@@ -870,6 +929,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/rxjs": {
@@ -920,6 +982,9 @@
       "integrity": "sha512-Z6sHIeTeeZrRAW83NI7FO7THF50cPCFkkuvVah3qmCqopY6FuoHKUBEENyGzQGH69LbGFYhEppY8KM/6JtVF6Q==",
       "dependencies": {
         "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "11.2.3"
       }
     },
     "node_modules/@angular/cdk": {
@@ -931,6 +996,10 @@
       },
       "optionalDependencies": {
         "parse5": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^11.0.0 || ^12.0.0-0",
+        "@angular/core": "^11.0.0 || ^12.0.0-0"
       }
     },
     "node_modules/@angular/cdk/node_modules/parse5": {
@@ -944,6 +1013,7 @@
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.2.2.tgz",
       "integrity": "sha512-rOVBzDzrMuOgJY43O46/7yYbncx0egGfr+DMJDQdazePGH1H3INN/eA9gkVcVK53ztCYb9X1sbZKOs9TUhF6nw==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "@angular-devkit/architect": "0.1102.2",
         "@angular-devkit/core": "11.2.2",
@@ -1044,6 +1114,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@angular/cli/node_modules/ansi-regex": {
@@ -1065,6 +1139,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@angular/cli/node_modules/chalk": {
@@ -1078,6 +1155,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@angular/cli/node_modules/cli-spinners": {
@@ -1087,6 +1167,9 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@angular/cli/node_modules/color-convert": {
@@ -1117,6 +1200,11 @@
       },
       "engines": {
         "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@angular/cli/node_modules/has-flag": {
@@ -1148,6 +1236,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@angular/cli/node_modules/ora": {
@@ -1167,6 +1258,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@angular/cli/node_modules/resolve": {
@@ -1177,6 +1271,9 @@
       "dependencies": {
         "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@angular/cli/node_modules/semver": {
@@ -1239,6 +1336,10 @@
       "integrity": "sha512-51gVmr942SZtAFmhVfp7/3fcTQ+Tia7UxWjv6iUtYF3oCvTWbo/J1zki2VNSfmMNKJV8MaMq6XUw8UWbHA0sgQ==",
       "dependencies": {
         "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "11.2.3",
+        "rxjs": "^6.5.3"
       }
     },
     "node_modules/@angular/compiler": {
@@ -1279,6 +1380,10 @@
       },
       "engines": {
         "node": ">=10.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler": "11.2.3",
+        "typescript": ">=4.0 <4.2"
       }
     },
     "node_modules/@angular/compiler-cli/node_modules/ansi-regex": {
@@ -1300,6 +1405,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@angular/compiler-cli/node_modules/cliui": {
@@ -1373,6 +1481,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@angular/compiler-cli/node_modules/y18n": {
@@ -1417,6 +1528,10 @@
       "integrity": "sha512-+G7rZj21Mcmf6nWjQ79EwomwEOVQ1WLqw6YvCXWzgJ9ZlVjLi/Sti0/jIzUpgK0E0Fn86yuXw/vgYq5kjGeOcQ==",
       "dependencies": {
         "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^6.5.3",
+        "zone.js": "^0.10.2 || ^0.11.3"
       }
     },
     "node_modules/@angular/flex-layout": {
@@ -1425,6 +1540,13 @@
       "integrity": "sha512-unfhw3abZuKtdwQicRStHCYGbANPTHYg4WNRQk/RC5Mxq+4WOp4Q8HI7GqRHCGUYDCGUP7w1sU/oDt8f09nM8w==",
       "dependencies": {
         "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "^11.0.0",
+        "@angular/common": ">=11.0.0",
+        "@angular/core": ">=11.0.0",
+        "@angular/platform-browser": ">=11.0.0",
+        "rxjs": "^6.0.0"
       }
     },
     "node_modules/@angular/forms": {
@@ -1433,6 +1555,12 @@
       "integrity": "sha512-VfyKV8IxHTclcHQmt5gjGFmKC1kGz7sdNLYsEM+M0y88Bsufh3VIhK4kspfO4nhJxVfh6HFOt1JVQ5bvo6PDlQ==",
       "dependencies": {
         "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "11.2.3",
+        "@angular/core": "11.2.3",
+        "@angular/platform-browser": "11.2.3",
+        "rxjs": "^6.5.3"
       }
     },
     "node_modules/@angular/material": {
@@ -1441,6 +1569,13 @@
       "integrity": "sha512-mPCGmWlDJ1HvHWDcvzOqoOYepW/8S1JHi+RD4jG7hn77+cD78BR+Ze8bQgJWADHvrtbElTmjB1ExB+gB+7gP8g==",
       "dependencies": {
         "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "^11.0.0 || ^12.0.0-0",
+        "@angular/cdk": "11.2.2",
+        "@angular/common": "^11.0.0 || ^12.0.0-0",
+        "@angular/core": "^11.0.0 || ^12.0.0-0",
+        "@angular/forms": "^11.0.0 || ^12.0.0-0"
       }
     },
     "node_modules/@angular/platform-browser": {
@@ -1449,6 +1584,16 @@
       "integrity": "sha512-S0IP/kGinIH18+gfnX0gLFLbP0Euw1RBceDt/WipYhUeFZZryQHvot/6KFLFtO+8rVunfrg+UyBiaK65/TT9Og==",
       "dependencies": {
         "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "11.2.3",
+        "@angular/common": "11.2.3",
+        "@angular/core": "11.2.3"
+      },
+      "peerDependenciesMeta": {
+        "@angular/animations": {
+          "optional": true
+        }
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
@@ -1457,6 +1602,12 @@
       "integrity": "sha512-QUPCvack7De6u5AqWcW8O6FzczwqoL858R1NlnqojnNbcnN/dCtXtKvvETEEgp/9VMwLfcuLd1BWdBJSah7f6A==",
       "dependencies": {
         "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "11.2.3",
+        "@angular/compiler": "11.2.3",
+        "@angular/core": "11.2.3",
+        "@angular/platform-browser": "11.2.3"
       }
     },
     "node_modules/@angular/router": {
@@ -1465,6 +1616,12 @@
       "integrity": "sha512-lRuEIlNj2BcBZ17mt5SZY7v80PsvlS4J6EbKSOFeSYhALM/AQnaaCdrrMlQ1WyEa5bBUabxGT9/zvahBosy2yA==",
       "dependencies": {
         "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "11.2.3",
+        "@angular/core": "11.2.3",
+        "@angular/platform-browser": "11.2.3",
+        "rxjs": "^6.5.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1510,6 +1667,10 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
@@ -1632,6 +1793,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -1658,6 +1822,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin/node_modules/@babel/code-frame": {
@@ -1865,6 +2032,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-explode-assignable-expression": {
@@ -2335,6 +2505,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-async-generator-functions/node_modules/@babel/helper-plugin-utils": {
@@ -2357,6 +2530,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-class-properties/node_modules/@babel/helper-plugin-utils": {
@@ -2379,6 +2555,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-dynamic-import/node_modules/@babel/helper-plugin-utils": {
@@ -2401,6 +2580,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-export-namespace-from/node_modules/@babel/helper-plugin-utils": {
@@ -2423,6 +2605,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-json-strings/node_modules/@babel/helper-plugin-utils": {
@@ -2445,6 +2630,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-logical-assignment-operators/node_modules/@babel/helper-plugin-utils": {
@@ -2467,6 +2655,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-nullish-coalescing-operator/node_modules/@babel/helper-plugin-utils": {
@@ -2489,6 +2680,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-numeric-separator/node_modules/@babel/helper-plugin-utils": {
@@ -2514,6 +2708,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-object-rest-spread/node_modules/@babel/helper-plugin-utils": {
@@ -2536,6 +2733,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-optional-catch-binding/node_modules/@babel/helper-plugin-utils": {
@@ -2559,6 +2759,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-optional-chaining/node_modules/@babel/helper-plugin-utils": {
@@ -2581,6 +2784,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-private-methods/node_modules/@babel/helper-plugin-utils": {
@@ -2603,6 +2809,9 @@
       },
       "engines": {
         "node": ">=4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-unicode-property-regex/node_modules/@babel/helper-plugin-utils": {
@@ -2621,6 +2830,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-bigint": {
@@ -2630,6 +2842,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
@@ -2639,6 +2854,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-dynamic-import": {
@@ -2648,6 +2866,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-export-namespace-from": {
@@ -2657,6 +2878,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
@@ -2666,6 +2890,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
@@ -2675,6 +2902,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
@@ -2684,6 +2914,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -2693,6 +2926,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
@@ -2702,6 +2938,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
@@ -2711,6 +2950,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
@@ -2720,6 +2962,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
@@ -2729,6 +2974,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
@@ -2738,6 +2986,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
@@ -2750,6 +3001,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions/node_modules/@babel/helper-plugin-utils": {
@@ -2770,6 +3024,9 @@
         "@babel/helper-module-imports": "^7.12.1",
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/helper-remap-async-to-generator": "^7.12.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-async-to-generator/node_modules/@babel/helper-module-imports": {
@@ -2816,6 +3073,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions/node_modules/@babel/helper-plugin-utils": {
@@ -2837,6 +3097,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping/node_modules/@babel/helper-plugin-utils": {
@@ -2864,6 +3127,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-classes/node_modules/@babel/code-frame": {
@@ -3079,6 +3345,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties/node_modules/@babel/helper-plugin-utils": {
@@ -3100,6 +3369,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-destructuring/node_modules/@babel/helper-plugin-utils": {
@@ -3122,6 +3394,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-dotall-regex/node_modules/@babel/helper-plugin-utils": {
@@ -3143,6 +3418,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-keys/node_modules/@babel/helper-plugin-utils": {
@@ -3165,6 +3443,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator/node_modules/@babel/helper-plugin-utils": {
@@ -3186,6 +3467,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-for-of/node_modules/@babel/helper-plugin-utils": {
@@ -3208,6 +3492,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-function-name/node_modules/@babel/code-frame": {
@@ -3329,6 +3616,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-literals/node_modules/@babel/helper-plugin-utils": {
@@ -3350,6 +3640,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-member-expression-literals/node_modules/@babel/helper-plugin-utils": {
@@ -3373,6 +3666,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-amd/node_modules/@babel/code-frame": {
@@ -3634,6 +3930,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs/node_modules/@babel/code-frame": {
@@ -3896,6 +4195,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs/node_modules/@babel/code-frame": {
@@ -4155,6 +4457,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd/node_modules/@babel/code-frame": {
@@ -4413,6 +4718,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-new-target": {
@@ -4425,6 +4733,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-new-target/node_modules/@babel/helper-plugin-utils": {
@@ -4447,6 +4758,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-object-super/node_modules/@babel/code-frame": {
@@ -4662,6 +4976,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-parameters/node_modules/@babel/helper-plugin-utils": {
@@ -4683,6 +5000,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-property-literals/node_modules/@babel/helper-plugin-utils": {
@@ -4704,6 +5024,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
@@ -4716,6 +5039,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-reserved-words/node_modules/@babel/helper-plugin-utils": {
@@ -4736,6 +5062,9 @@
         "@babel/helper-module-imports": "^7.12.5",
         "@babel/helper-plugin-utils": "^7.10.4",
         "semver": "^5.5.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-runtime/node_modules/@babel/helper-module-imports": {
@@ -4791,6 +5120,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties/node_modules/@babel/helper-plugin-utils": {
@@ -4813,6 +5145,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-spread/node_modules/@babel/helper-plugin-utils": {
@@ -4834,6 +5169,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-sticky-regex/node_modules/@babel/helper-plugin-utils": {
@@ -4855,6 +5193,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-template-literals/node_modules/@babel/helper-plugin-utils": {
@@ -4876,6 +5217,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol/node_modules/@babel/helper-plugin-utils": {
@@ -4897,6 +5241,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes/node_modules/@babel/helper-plugin-utils": {
@@ -4919,6 +5266,9 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-unicode-regex/node_modules/@babel/helper-plugin-utils": {
@@ -5002,6 +5352,9 @@
         "@babel/types": "^7.12.11",
         "core-js-compat": "^3.8.0",
         "semver": "^5.5.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-env/node_modules/@babel/helper-module-imports": {
@@ -5032,6 +5385,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-env/node_modules/@babel/plugin-syntax-class-properties/node_modules/@babel/helper-plugin-utils": {
@@ -5076,6 +5432,9 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -5183,12 +5542,17 @@
       "integrity": "sha512-K/AiykA4YbHKE6XKEtZ0ZvVRQocUHyk+79HYWIfhGy3teHpzxsUqB/UjDaxivgBd6dF6ihlzgEbgrDMHlGNwGg==",
       "dependencies": {
         "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^11.0.0",
+        "@fortawesome/fontawesome-svg-core": "^1.2.27"
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "0.2.34",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.34.tgz",
       "integrity": "sha512-XcIn3iYbTEzGIxD0/dY5+4f019jIcEIWBiHc3KrmK/ROahwxmZ/s+tdj97p/5K0klz4zZUiMfUlYP0ajhSJjmA==",
+      "hasInstallScript": true,
       "engines": {
         "node": ">=6"
       }
@@ -5197,6 +5561,7 @@
       "version": "1.2.34",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.34.tgz",
       "integrity": "sha512-0KNN0nc5eIzaJxlv43QcDmTkDY1CqeN6J7OCGSs+fwGPdtv0yOQqRjieopBCmw+yd7uD3N2HeNL3Zm5isDleLg==",
+      "hasInstallScript": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^0.2.34"
       },
@@ -5208,6 +5573,7 @@
       "version": "0.2.34",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.34.tgz",
       "integrity": "sha512-XcIn3iYbTEzGIxD0/dY5+4f019jIcEIWBiHc3KrmK/ROahwxmZ/s+tdj97p/5K0klz4zZUiMfUlYP0ajhSJjmA==",
+      "hasInstallScript": true,
       "engines": {
         "node": ">=6"
       }
@@ -5216,6 +5582,7 @@
       "version": "5.15.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.2.tgz",
       "integrity": "sha512-Uv5NQCYjyisNVTu/1Xjs+z8vwQjbfT6hiqYvQNfF0n8qdgfWLM581bAfVMQ3BCs1SPy+eEUKNcGkK4n0FihFHg==",
+      "hasInstallScript": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^0.2.34"
       },
@@ -5227,6 +5594,7 @@
       "version": "5.15.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.2.tgz",
       "integrity": "sha512-ZfCU+QjaFsdNZmOGmfqEWhzI3JOe37x5dF4kz9GeXvKn/sTxhqMtZ7mh3lBf76SvcYY5/GKFuyG7p1r4iWMQqw==",
+      "hasInstallScript": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^0.2.34"
       },
@@ -5238,6 +5606,7 @@
       "version": "0.2.34",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.34.tgz",
       "integrity": "sha512-XcIn3iYbTEzGIxD0/dY5+4f019jIcEIWBiHc3KrmK/ROahwxmZ/s+tdj97p/5K0klz4zZUiMfUlYP0ajhSJjmA==",
+      "hasInstallScript": true,
       "engines": {
         "node": ">=6"
       }
@@ -5246,24 +5615,28 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
       "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
+      "deprecated": "Moved to 'npm install @sideway/address'",
       "dev": true
     },
     "node_modules/@hapi/bourne": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "deprecated": "This version has been deprecated and is no longer supported or maintained",
       "dev": true
     },
     "node_modules/@hapi/hoek": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
       "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
+      "deprecated": "This version has been deprecated and is no longer supported or maintained",
       "dev": true
     },
     "node_modules/@hapi/joi": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
       "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "deprecated": "Switch to 'npm install joi'",
       "dev": true,
       "dependencies": {
         "@hapi/address": "2.x.x",
@@ -5276,6 +5649,7 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
       "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "deprecated": "This version has been deprecated and is no longer supported or maintained",
       "dev": true,
       "dependencies": {
         "@hapi/hoek": "^8.3.0"
@@ -5422,6 +5796,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/console/node_modules/chalk": {
@@ -5435,6 +5812,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/console/node_modules/color-convert": {
@@ -5559,6 +5939,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/core/node_modules/chalk": {
@@ -5572,6 +5955,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/core/node_modules/color-convert": {
@@ -5675,6 +6061,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/environment/node_modules/chalk": {
@@ -5688,6 +6077,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/environment/node_modules/color-convert": {
@@ -5781,6 +6173,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/fake-timers/node_modules/chalk": {
@@ -5794,6 +6189,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/fake-timers/node_modules/color-convert": {
@@ -5884,6 +6282,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/globals/node_modules/chalk": {
@@ -5897,6 +6298,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/globals/node_modules/color-convert": {
@@ -6011,6 +6415,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/reporters/node_modules/chalk": {
@@ -6024,6 +6431,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/reporters/node_modules/color-convert": {
@@ -6156,6 +6566,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/test-result/node_modules/chalk": {
@@ -6169,6 +6582,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/test-result/node_modules/color-convert": {
@@ -6287,6 +6703,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/transform/node_modules/chalk": {
@@ -6300,6 +6719,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/transform/node_modules/color-convert": {
@@ -6375,6 +6797,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/types/node_modules/chalk": {
@@ -6461,6 +6886,11 @@
         "node": ">= 10.13.0",
         "npm": "^6.11.0 || ^7.5.6",
         "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler-cli": "^11.0.0 || ^11.2.0-next",
+        "typescript": "~4.0.0 || ~4.1.0",
+        "webpack": "^4.0.0"
       }
     },
     "node_modules/@ngx-translate/core": {
@@ -6469,6 +6899,10 @@
       "integrity": "sha512-+tzEp8wlqEnw0Gc7jtVRAJ6RteUjXw6JJR4O65KlnxOmJrCGPI0xjV/lKRnQeU0w4i96PQs/jtpL921Wrb7PWg==",
       "dependencies": {
         "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=10.0.0",
+        "rxjs": ">=6.5.3"
       }
     },
     "node_modules/@ngx-translate/http-loader": {
@@ -6477,6 +6911,11 @@
       "integrity": "sha512-LCekn6qCbeXWlhESCxU1rAbZz33WzDG0lI7Ig0pYC1o5YxJWrkU9y3Y4tNi+jakQ7R6YhTR2D3ox6APxDtA0wA==",
       "dependencies": {
         "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=10.0.0",
+        "@ngx-translate/core": ">=13.0.0",
+        "rxjs": ">=6.5.3"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -6716,6 +7155,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@schematics/angular/node_modules/tslib": {
@@ -6785,6 +7228,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@schematics/update/node_modules/ini": {
@@ -6852,6 +7299,16 @@
         "d3-time-format": "^3.0.0",
         "d3-transition": "^2.0.0",
         "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": ">=11.0.0",
+        "@angular/cdk": ">=11.0.0",
+        "@angular/common": ">=11.0.0",
+        "@angular/core": ">=11.0.0",
+        "@angular/forms": ">=11.0.0",
+        "@angular/platform-browser": ">=11.0.0",
+        "@angular/platform-browser-dynamic": ">=11.0.0",
+        "rxjs": "6.x"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -7017,6 +7474,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@types/jest/node_modules/chalk": {
@@ -7030,6 +7490,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@types/jest/node_modules/color-convert": {
@@ -7567,19 +8030,29 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      }
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
     },
     "node_modules/alphanum-sort": {
       "version": "1.0.2",
@@ -7593,6 +8066,10 @@
       "integrity": "sha512-9wC8I3e3cN6rMBOlo5JB2y3Fd2erp8pJ67t4vEVzyPbnRG6BJ4rreSOznSL9zw/2SjhC9kRV2OfFie29CUCzEg==",
       "dependencies": {
         "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=8.0.0",
+        "@angular/core": ">=8.0.0"
       }
     },
     "node_modules/angular-playground": {
@@ -7619,6 +8096,17 @@
       },
       "bin": {
         "angular-playground": "dist/bin/index.js"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=9.0.0",
+        "@angular/compiler": ">=9.0.0",
+        "@angular/core": ">=9.0.0",
+        "@angular/forms": ">=9.0.0",
+        "@angular/platform-browser": ">=9.0.0",
+        "@angular/platform-browser-dynamic": ">=9.0.0",
+        "rxjs": ">=6.5.4",
+        "tslib": ">=1.10.0",
+        "zone.js": ">=0.10.2"
       }
     },
     "node_modules/angular-playground/node_modules/@angular-devkit/core": {
@@ -8065,6 +8553,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/angular-playground/node_modules/astral-regex": {
@@ -8099,6 +8590,9 @@
       },
       "engines": {
         "node": ">= 8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/angular-playground/node_modules/babel-jest/node_modules/chalk": {
@@ -8139,6 +8633,9 @@
       },
       "engines": {
         "node": ">= 8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/angular-playground/node_modules/braces": {
@@ -8400,6 +8897,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/angular-playground/node_modules/has-flag": {
@@ -9333,6 +9833,9 @@
       },
       "engines": {
         "node": ">= 6"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/angular-playground/node_modules/jest/node_modules/babel-plugin-istanbul": {
@@ -9373,6 +9876,9 @@
       },
       "engines": {
         "node": ">= 6"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/angular-playground/node_modules/jest/node_modules/cliui": {
@@ -9507,7 +10013,9 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -10591,6 +11099,14 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/angular-playground/node_modules/locate-path": {
@@ -10636,6 +11152,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/angular-playground/node_modules/node-notifier": {
@@ -11140,6 +11659,18 @@
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/angular-playground/node_modules/yargs": {
@@ -11196,6 +11727,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-html": {
@@ -11520,6 +12054,13 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/aws-sign2": {
@@ -11563,6 +12104,9 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/babel-jest/node_modules/@jest/types": {
@@ -11600,6 +12144,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/babel-jest/node_modules/chalk": {
@@ -11613,6 +12160,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/babel-jest/node_modules/color-convert": {
@@ -11667,6 +12217,10 @@
       },
       "engines": {
         "node": ">= 8.9"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "webpack": ">=2"
       }
     },
     "node_modules/babel-loader/node_modules/json5": {
@@ -11752,6 +12306,9 @@
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/babel-preset-jest": {
@@ -11765,6 +12322,9 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/babel-preset-jest/node_modules/babel-preset-current-node-syntax": {
@@ -11785,6 +12345,9 @@
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -11865,7 +12428,21 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/batch": {
       "version": "0.6.1",
@@ -12158,7 +12735,21 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/browserify-zlib": {
       "version": "0.2.0",
@@ -12186,6 +12777,10 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/browserstack": {
@@ -12223,6 +12818,20 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -12353,6 +12962,9 @@
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase": {
@@ -12362,6 +12974,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-api": {
@@ -12380,7 +12995,11 @@
       "version": "1.0.30001241",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz",
       "integrity": "sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/canonical-path": {
       "version": "1.0.0",
@@ -12461,6 +13080,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
       "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -12510,6 +13130,9 @@
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": ">=4.0.1"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -12573,6 +13196,9 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-truncate": {
@@ -12586,6 +13212,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-width": {
@@ -12725,19 +13354,32 @@
         "sprintf-js": "^1.1.2",
         "tslib": "^1.10.0",
         "zone.js": "~0.10.3"
+      },
+      "peerDependencies": {
+        "@angular/compiler": ">=2.3.1 <12.0.0 || ^11.0.0-next || ^11.1.0-next || ^11.2.0-next",
+        "@angular/core": ">=2.3.1 <12.0.0 || ^11.0.0-next || ^11.1.0-next || ^11.2.0-next",
+        "tslint": "^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/codelyzer/node_modules/@angular/compiler": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-9.0.0.tgz",
       "integrity": "sha512-ctjwuntPfZZT2mNj2NDIVu51t9cvbhl/16epc5xEwyzyDt76pX9UgwvY+MbXrf/C/FWwdtmNtfP698BKI+9leQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "tslib": "^1.10.0"
+      }
     },
     "node_modules/codelyzer/node_modules/@angular/core": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-9.0.0.tgz",
       "integrity": "sha512-6Pxgsrf0qF9iFFqmIcWmjJGkkCaCm6V5QNnxMy2KloO3SDq6QuMVRbN9RtC8Urmo25LP+eZ6ZgYqFYpdD8Hd9w==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "rxjs": "^6.5.3",
+        "tslib": "^1.10.0",
+        "zone.js": "~0.10.2"
+      }
     },
     "node_modules/codelyzer/node_modules/source-map": {
       "version": "0.5.7",
@@ -13053,6 +13695,13 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.37.0 || ^5.0.0"
       }
     },
     "node_modules/copy-webpack-plugin/node_modules/ajv": {
@@ -13065,6 +13714,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/copy-webpack-plugin/node_modules/p-limit": {
@@ -13077,6 +13730,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/copy-webpack-plugin/node_modules/schema-utils": {
@@ -13091,6 +13747,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/copy-webpack-plugin/node_modules/source-map": {
@@ -13116,7 +13776,12 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
       "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==",
-      "dev": true
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.15.1",
@@ -13126,6 +13791,10 @@
       "dependencies": {
         "browserslist": "^4.16.6",
         "semver": "7.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-js-compat/node_modules/semver": {
@@ -13172,6 +13841,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/create-ecdh": {
@@ -13240,6 +13912,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/critters/node_modules/chalk": {
@@ -13253,6 +13928,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/critters/node_modules/color-convert": {
@@ -13371,6 +14049,9 @@
       },
       "engines": {
         "node": ">= 10"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.9"
       }
     },
     "node_modules/css-loader": {
@@ -13394,6 +14075,13 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.27.0 || ^5.0.0"
       }
     },
     "node_modules/css-loader/node_modules/ajv": {
@@ -13406,6 +14094,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/css-loader/node_modules/schema-utils": {
@@ -13420,6 +14112,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/css-parse": {
@@ -13463,6 +14159,9 @@
         "domhandler": "^4.2.0",
         "domutils": "^2.6.0",
         "nth-check": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/css-selector-tokenizer": {
@@ -13504,6 +14203,9 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/css/node_modules/source-map": {
@@ -13558,6 +14260,13 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/cssnano"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.1"
       }
     },
     "node_modules/cssnano-preset-default": {
@@ -13598,6 +14307,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/cssnano-utils": {
@@ -13607,6 +14319,9 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/csso": {
@@ -13787,6 +14502,9 @@
         "d3-ease": "1 - 2",
         "d3-interpolate": "1 - 2",
         "d3-timer": "1 - 2"
+      },
+      "peerDependencies": {
+        "d3-selection": "2"
       }
     },
     "node_modules/damerau-levenshtein": {
@@ -13825,12 +14543,18 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
       "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
       "engines": {
         "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decamelize": {
@@ -13875,6 +14599,9 @@
         "object-is": "^1.0.1",
         "object-keys": "^1.1.1",
         "regexp.prototype.flags": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/deep-is": {
@@ -14207,6 +14934,9 @@
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
         "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
     "node_modules/domain-browser": {
@@ -14223,7 +14953,13 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
       "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
     },
     "node_modules/domexception": {
       "version": "2.0.1",
@@ -14256,6 +14992,9 @@
       },
       "engines": {
         "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/domutils": {
@@ -14267,6 +15006,9 @@
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/duplexify": {
@@ -14345,6 +15087,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {
@@ -14432,7 +15177,10 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/env-paths": {
       "version": "2.2.0",
@@ -14491,6 +15239,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-to-primitive": {
@@ -14505,6 +15256,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es6-promise": {
@@ -14589,6 +15343,9 @@
       },
       "engines": {
         "node": ">=4.0.0"
+      },
+      "peerDependencies": {
+        "prettier": ">= 0.11.0"
       }
     },
     "node_modules/eslint-plugin-prettier/node_modules/jest-docblock": {
@@ -14868,6 +15625,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/expect/node_modules/chalk": {
@@ -14881,6 +15641,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/expect/node_modules/color-convert": {
@@ -15206,6 +15969,9 @@
       "dev": true,
       "engines": {
         "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -15281,6 +16047,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-loader": {
@@ -15294,6 +16063,13 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/file-loader/node_modules/ajv": {
@@ -15306,6 +16082,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/file-loader/node_modules/schema-utils": {
@@ -15320,6 +16100,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -15386,6 +16170,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
     "node_modules/find-cache-dir/node_modules/find-up": {
@@ -15495,6 +16282,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/find-process/node_modules/chalk": {
@@ -15508,6 +16298,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/find-process/node_modules/color-convert": {
@@ -15580,6 +16373,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/flush-write-stream": {
@@ -15597,8 +16393,19 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
       "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
       "engines": {
         "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/for-in": {
@@ -15661,6 +16468,10 @@
       "dev": true,
       "engines": {
         "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/infusion"
       }
     },
     "node_modules/fragment-cache": {
@@ -15748,7 +16559,9 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -15832,6 +16645,9 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-own-enumerable-property-symbols": {
@@ -15856,6 +16672,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stdin": {
@@ -15912,6 +16731,9 @@
       },
       "engines": {
         "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -15996,6 +16818,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glur": {
@@ -16035,6 +16860,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.3",
@@ -16084,6 +16910,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-unicode": {
@@ -16187,7 +17016,21 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
@@ -16542,6 +17385,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -16570,6 +17414,7 @@
       "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
       "integrity": "sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "ci-info": "^2.0.0",
@@ -16588,6 +17433,10 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/husky"
       }
     },
     "node_modules/husky/node_modules/ansi-styles": {
@@ -16600,6 +17449,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/husky/node_modules/chalk": {
@@ -16613,6 +17465,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/husky/node_modules/color-convert": {
@@ -16660,6 +17515,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/husky/node_modules/has-flag": {
@@ -16682,6 +17540,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/husky/node_modules/locate-path": {
@@ -16694,6 +17555,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/husky/node_modules/p-limit": {
@@ -16706,6 +17570,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/husky/node_modules/p-locate": {
@@ -16718,6 +17585,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/husky/node_modules/parse-json": {
@@ -16733,6 +17603,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/husky/node_modules/path-exists": {
@@ -16796,13 +17669,30 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/iferr": {
       "version": "0.1.5",
@@ -16858,6 +17748,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
@@ -16974,6 +17867,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/inquirer/node_modules/chalk": {
@@ -16987,6 +17883,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/inquirer/node_modules/color-convert": {
@@ -17134,6 +18033,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-arrayish": {
@@ -17167,6 +18069,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-ci": {
@@ -17211,6 +18116,9 @@
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-data-descriptor": {
@@ -17244,6 +18152,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-descriptor": {
@@ -17279,6 +18190,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extendable": {
@@ -17423,6 +18337,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-regexp": {
@@ -17459,6 +18376,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-typedarray": {
@@ -17587,6 +18507,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/istanbul-lib-report/node_modules/semver": {
@@ -17756,6 +18679,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-changed-files/node_modules/chalk": {
@@ -17769,6 +18695,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-changed-files/node_modules/color-convert": {
@@ -17821,6 +18750,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/jest-changed-files/node_modules/get-stream": {
@@ -17833,6 +18765,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-changed-files/node_modules/has-flag": {
@@ -17949,6 +18884,14 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      },
+      "peerDependencies": {
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-config/node_modules/@jest/types": {
@@ -17995,6 +18938,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-config/node_modules/chalk": {
@@ -18008,6 +18954,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-config/node_modules/color-convert": {
@@ -18104,6 +19053,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-dev-server/node_modules/chalk": {
@@ -18183,6 +19135,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-diff/node_modules/chalk": {
@@ -18309,6 +19264,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-each/node_modules/chalk": {
@@ -18322,6 +19280,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-each/node_modules/color-convert": {
@@ -18446,6 +19407,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/chalk": {
@@ -18459,6 +19423,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/color-convert": {
@@ -18552,6 +19519,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-environment-node/node_modules/chalk": {
@@ -18565,6 +19535,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-environment-node/node_modules/color-convert": {
@@ -18628,6 +19601,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-environment-puppeteer/node_modules/chalk": {
@@ -18753,6 +19729,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-haste-map/node_modules/chalk": {
@@ -18766,6 +19745,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-haste-map/node_modules/color-convert": {
@@ -18824,6 +19806,9 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "jest": ">=20 <=24"
       }
     },
     "node_modules/jest-image-snapshot/node_modules/ansi-styles": {
@@ -18945,6 +19930,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-jasmine2/node_modules/chalk": {
@@ -18958,6 +19946,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-jasmine2/node_modules/color-convert": {
@@ -19072,6 +20063,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
@@ -19134,6 +20126,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-leak-detector/node_modules/chalk": {
@@ -19147,6 +20142,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-leak-detector/node_modules/color-convert": {
@@ -19277,6 +20275,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-matcher-utils/node_modules/chalk": {
@@ -19290,6 +20291,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-matcher-utils/node_modules/color-convert": {
@@ -19449,6 +20453,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-message-util/node_modules/chalk": {
@@ -19462,6 +20469,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-message-util/node_modules/color-convert": {
@@ -19572,6 +20582,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-mock/node_modules/chalk": {
@@ -19585,6 +20598,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-mock/node_modules/color-convert": {
@@ -19633,6 +20649,14 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-preset-angular": {
@@ -19646,6 +20670,11 @@
       },
       "engines": {
         "node": ">= 10"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=2.0.0",
+        "@angular/platform-browser-dynamic": ">=2.0.0",
+        "jest": "^26.0.0"
       }
     },
     "node_modules/jest-preset-angular/node_modules/@jest/types": {
@@ -19692,6 +20721,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-preset-angular/node_modules/chalk": {
@@ -19705,6 +20737,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-preset-angular/node_modules/color-convert": {
@@ -19775,6 +20810,9 @@
       "dependencies": {
         "expect-puppeteer": "^4.4.0",
         "jest-environment-puppeteer": "^4.4.0"
+      },
+      "peerDependencies": {
+        "puppeteer": ">= 1.5.0 < 3"
       }
     },
     "node_modules/jest-regex-util": {
@@ -19854,6 +20892,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-resolve-dependencies/node_modules/chalk": {
@@ -19867,6 +20908,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-resolve-dependencies/node_modules/color-convert": {
@@ -19943,6 +20987,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-resolve/node_modules/chalk": {
@@ -19956,6 +21003,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-resolve/node_modules/color-convert": {
@@ -19993,6 +21043,9 @@
       "dependencies": {
         "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jest-resolve/node_modules/supports-color": {
@@ -20073,6 +21126,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-runner/node_modules/chalk": {
@@ -20086,6 +21142,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-runner/node_modules/color-convert": {
@@ -20212,6 +21271,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-runtime/node_modules/camelcase": {
@@ -20234,6 +21296,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-runtime/node_modules/cliui": {
@@ -20477,6 +21542,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-snapshot/node_modules/chalk": {
@@ -20490,6 +21558,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-snapshot/node_modules/color-convert": {
@@ -20637,6 +21708,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-util/node_modules/chalk": {
@@ -20650,6 +21724,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-util/node_modules/color-convert": {
@@ -20752,6 +21829,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-validate/node_modules/chalk": {
@@ -20765,6 +21845,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-validate/node_modules/color-convert": {
@@ -20889,6 +21972,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-watcher/node_modules/chalk": {
@@ -20902,6 +21988,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-watcher/node_modules/color-convert": {
@@ -21022,6 +22111,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest/node_modules/camelcase": {
@@ -21044,6 +22136,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest/node_modules/cliui": {
@@ -21339,6 +22434,14 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsdom/node_modules/acorn": {
@@ -21380,6 +22483,18 @@
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -21456,7 +22571,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
+      "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
@@ -21551,6 +22666,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
       "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "deprecated": "use String.prototype.padStart()",
       "dev": true
     },
     "node_modules/less": {
@@ -21560,9 +22676,6 @@
       "dev": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
-        "errno": "^0.1.1",
-        "graceful-fs": "^4.1.2",
-        "mime": "^1.4.1",
         "parse-node-version": "^1.0.1",
         "tslib": "^1.10.0"
       },
@@ -21573,8 +22686,11 @@
         "node": ">=6"
       },
       "optionalDependencies": {
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
         "image-size": "~0.5.0",
         "make-dir": "^2.1.0",
+        "mime": "^1.4.1",
         "needle": "^2.5.2",
         "source-map": "~0.6.0"
       }
@@ -21591,6 +22707,14 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "less": "^3.5.0 || ^4.0.0",
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/less-loader/node_modules/ajv": {
@@ -21603,6 +22727,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/less-loader/node_modules/schema-utils": {
@@ -21617,6 +22745,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/less/node_modules/make-dir": {
@@ -21749,6 +22881,9 @@
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
       }
     },
     "node_modules/lint-staged/node_modules/ansi-styles": {
@@ -21761,6 +22896,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/lint-staged/node_modules/chalk": {
@@ -21774,6 +22912,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/lint-staged/node_modules/color-convert": {
@@ -21851,6 +22992,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/lint-staged/node_modules/get-stream": {
@@ -21863,6 +23007,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lint-staged/node_modules/has-flag": {
@@ -21885,6 +23032,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lint-staged/node_modules/is-stream": {
@@ -21921,6 +23071,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lint-staged/node_modules/path-key": {
@@ -22007,6 +23160,9 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "enquirer": ">= 2.3.0 < 3"
       }
     },
     "node_modules/listr2/node_modules/ansi-regex": {
@@ -22028,6 +23184,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/listr2/node_modules/chalk": {
@@ -22041,6 +23200,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/listr2/node_modules/color-convert": {
@@ -22106,6 +23268,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/load-json-file": {
@@ -22229,6 +23394,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/log-symbols/node_modules/chalk": {
@@ -22242,6 +23410,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/log-symbols/node_modules/color-convert": {
@@ -22296,6 +23467,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/log-update/node_modules/ansi-regex": {
@@ -22317,6 +23491,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/log-update/node_modules/color-convert": {
@@ -22349,6 +23526,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/log-update/node_modules/strip-ansi": {
@@ -22384,6 +23564,10 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/lolex": {
@@ -22438,6 +23622,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-dir/node_modules/semver": {
@@ -22745,6 +23932,13 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.4.0 || ^5.0.0"
       }
     },
     "node_modules/mini-css-extract-plugin/node_modules/ajv": {
@@ -22757,6 +23951,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
@@ -22771,6 +23969,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/mini-css-extract-plugin/node_modules/source-map": {
@@ -23210,6 +24412,10 @@
       "integrity": "sha512-DDRwEssQRjjgPElEjF1emORoUEnF6OMZ20xnQBLueSHitM7XnIUErYVe9GMmm/jCtI+iPvJPEedyxMPl62nHLw==",
       "dependencies": {
         "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@juggle/resize-observer": ">=3.3.1",
+        "echarts": ">=5.0.0"
       }
     },
     "node_modules/nice-try": {
@@ -23452,6 +24658,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm-bundled": {
@@ -23574,6 +24783,9 @@
       "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/number-is-nan": {
@@ -23651,7 +24863,10 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
       "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/object-is": {
       "version": "1.1.5",
@@ -23664,6 +24879,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object-keys": {
@@ -23700,6 +24918,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.getownpropertydescriptors": {
@@ -23713,6 +24934,9 @@
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.getownpropertydescriptors/node_modules/es-abstract": {
@@ -23735,6 +24959,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.pick": {
@@ -23795,6 +25022,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/open": {
@@ -23808,6 +25038,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/opencollective-postinstall": {
@@ -23874,6 +25107,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ora/node_modules/ansi-regex": {
@@ -23895,6 +25131,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ora/node_modules/chalk": {
@@ -23908,6 +25147,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/ora/node_modules/cli-spinners": {
@@ -23917,6 +25159,9 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ora/node_modules/color-convert": {
@@ -24031,6 +25276,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
@@ -24055,6 +25303,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-reduce": {
@@ -24367,6 +25618,9 @@
       "dev": true,
       "engines": {
         "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/pify": {
@@ -24515,6 +25769,10 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-calc": {
@@ -24525,6 +25783,9 @@
       "dependencies": {
         "postcss-selector-parser": "^6.0.2",
         "postcss-value-parser": "^4.0.2"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.2"
       }
     },
     "node_modules/postcss-colormin": {
@@ -24540,6 +25801,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-convert-values": {
@@ -24552,6 +25816,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-discard-comments": {
@@ -24561,6 +25828,9 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-discard-duplicates": {
@@ -24570,6 +25840,9 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-discard-empty": {
@@ -24579,6 +25852,9 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-discard-overridden": {
@@ -24588,6 +25864,9 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-import": {
@@ -24602,6 +25881,9 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
       }
     },
     "node_modules/postcss-loader": {
@@ -24618,6 +25900,14 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "postcss": "^7.0.0 || ^8.0.1",
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/postcss-loader/node_modules/ajv": {
@@ -24630,6 +25920,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/postcss-loader/node_modules/schema-utils": {
@@ -24644,6 +25938,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/postcss-loader/node_modules/semver": {
@@ -24673,6 +25971,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-merge-rules": {
@@ -24689,6 +25990,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-minify-font-values": {
@@ -24701,6 +26005,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-minify-gradients": {
@@ -24715,6 +26022,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-minify-params": {
@@ -24731,6 +26041,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-minify-selectors": {
@@ -24744,6 +26057,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-modules-extract-imports": {
@@ -24753,6 +26069,9 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/postcss-modules-local-by-default": {
@@ -24767,6 +26086,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/postcss-modules-scope": {
@@ -24779,6 +26101,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/postcss-modules-values": {
@@ -24791,6 +26116,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/postcss-normalize-charset": {
@@ -24800,6 +26128,9 @@
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-display-values": {
@@ -24813,6 +26144,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-positions": {
@@ -24825,6 +26159,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-repeat-style": {
@@ -24838,6 +26175,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-string": {
@@ -24850,6 +26190,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-timing-functions": {
@@ -24863,6 +26206,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-unicode": {
@@ -24876,6 +26222,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-url": {
@@ -24890,6 +26239,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-whitespace": {
@@ -24902,6 +26254,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-ordered-values": {
@@ -24915,6 +26270,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-reduce-initial": {
@@ -24928,6 +26286,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-reduce-transforms": {
@@ -24941,6 +26302,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-selector-parser": {
@@ -24967,6 +26331,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-unique-selectors": {
@@ -24981,6 +26348,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -25038,6 +26408,9 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pretty-format": {
@@ -25074,6 +26447,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/pretty-format/node_modules/color-convert": {
@@ -25112,6 +26488,9 @@
       },
       "engines": {
         "node": ">=10.13"
+      },
+      "peerDependencies": {
+        "prettier": ">=2.0.0"
       }
     },
     "node_modules/pretty-quick/node_modules/ansi-styles": {
@@ -25124,6 +26503,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/pretty-quick/node_modules/chalk": {
@@ -25189,6 +26571,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/pretty-quick/node_modules/find-up": {
@@ -25214,6 +26599,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pretty-quick/node_modules/has-flag": {
@@ -25811,6 +27199,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/protractor/node_modules/wrap-ansi/node_modules/strip-ansi": {
@@ -25965,6 +27356,7 @@
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
       "integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "debug": "^4.1.0",
         "extract-zip": "^1.6.6",
@@ -26016,6 +27408,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
@@ -26040,7 +27433,21 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -26105,6 +27512,13 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/raw-loader/node_modules/ajv": {
@@ -26117,6 +27531,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/raw-loader/node_modules/schema-utils": {
@@ -26131,6 +27549,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/react-is": {
@@ -26194,6 +27616,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg-up/node_modules/find-up": {
@@ -26264,6 +27689,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
@@ -26380,6 +27808,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/regexpu-core": {
@@ -26454,6 +27885,7 @@
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -26491,12 +27923,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
       }
     },
     "node_modules/request-promise-native": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
       "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
       "dev": true,
       "dependencies": {
         "request-promise-core": "1.1.4",
@@ -26505,6 +27941,9 @@
       },
       "engines": {
         "node": ">=0.12.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
       }
     },
     "node_modules/request/node_modules/qs": {
@@ -26520,6 +27959,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
@@ -26553,6 +27993,9 @@
       "dev": true,
       "dependencies": {
         "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-cwd": {
@@ -26593,6 +28036,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
     },
     "node_modules/resolve-url-loader": {
@@ -26609,6 +28053,18 @@
       },
       "engines": {
         "node": ">=8.9"
+      },
+      "peerDependencies": {
+        "rework": "1.0.1",
+        "rework-visit": "1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rework": {
+          "optional": true
+        },
+        "rework-visit": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve-url-loader/node_modules/postcss": {
@@ -26623,6 +28079,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/resolve-url-loader/node_modules/source-map": {
@@ -26709,6 +28169,9 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ripemd160": {
@@ -26741,6 +28204,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -26772,6 +28236,20 @@
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -26832,6 +28310,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
       "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+      "deprecated": "some dependency vulnerabilities fixed, support for node < 10 dropped, and newer ECMAScript syntax/features added",
       "dev": true,
       "dependencies": {
         "@cnakazawa/watch": "^1.0.3",
@@ -27023,6 +28502,27 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "fibers": ">= 3.1.0",
+        "node-sass": "^4.0.0 || ^5.0.0",
+        "sass": "^1.3.0",
+        "webpack": "^4.36.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fibers": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
       }
     },
     "node_modules/sass-loader/node_modules/ajv": {
@@ -27035,6 +28535,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/sass-loader/node_modules/schema-utils": {
@@ -27049,6 +28553,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/saucelabs": {
@@ -27093,6 +28601,10 @@
       },
       "engines": {
         "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/select-hose": {
@@ -27210,6 +28722,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/send": {
@@ -27516,6 +29031,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/slice-ansi/node_modules/color-convert": {
@@ -27739,6 +29257,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
@@ -27814,6 +29333,13 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/source-map-loader/node_modules/ajv": {
@@ -27826,6 +29352,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/source-map-loader/node_modules/iconv-lite": {
@@ -27852,6 +29382,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/source-map-loader/node_modules/source-map": {
@@ -28005,6 +29539,9 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1 || ^2 || ^3 || ^4 || ^5"
       }
     },
     "node_modules/speed-measure-webpack-plugin/node_modules/ansi-styles": {
@@ -28017,6 +29554,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/speed-measure-webpack-plugin/node_modules/chalk": {
@@ -28030,6 +29570,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/speed-measure-webpack-plugin/node_modules/color-convert": {
@@ -28104,6 +29647,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -28325,6 +29873,9 @@
       "dependencies": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimend/node_modules/es-abstract": {
@@ -28347,6 +29898,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
@@ -28357,6 +29911,9 @@
       "dependencies": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart/node_modules/es-abstract": {
@@ -28379,6 +29936,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/stringify-object": {
@@ -28454,6 +30014,13 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/style-loader/node_modules/ajv": {
@@ -28466,6 +30033,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/style-loader/node_modules/schema-utils": {
@@ -28480,6 +30051,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/stylehacks": {
@@ -28493,6 +30068,9 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/stylus": {
@@ -28531,6 +30109,14 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "stylus": ">=0.52.4",
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/stylus-loader/node_modules/ajv": {
@@ -28543,6 +30129,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/stylus-loader/node_modules/schema-utils": {
@@ -28557,6 +30147,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/stylus/node_modules/debug": {
@@ -28672,6 +30266,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/svgo/node_modules/chalk": {
@@ -28685,6 +30282,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/svgo/node_modules/color-convert": {
@@ -28799,6 +30399,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/terser": {
@@ -28836,6 +30439,13 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/ajv": {
@@ -28848,6 +30458,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/p-limit": {
@@ -28860,6 +30474,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
@@ -28874,6 +30491,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/source-map": {
@@ -29111,6 +30732,10 @@
       },
       "engines": {
         "node": ">= 10"
+      },
+      "peerDependencies": {
+        "jest": ">=26 <27",
+        "typescript": ">=3.8 <5.0"
       }
     },
     "node_modules/ts-jest/node_modules/mkdirp": {
@@ -29151,6 +30776,9 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.0"
       }
     },
     "node_modules/ts-pnp": {
@@ -29160,6 +30788,11 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/tslib": {
@@ -29171,6 +30804,7 @@
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
       "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
+      "deprecated": "TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -29192,6 +30826,9 @@
       },
       "engines": {
         "node": ">=4.8.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 4.0.0-dev"
       }
     },
     "node_modules/tslint-config-prettier": {
@@ -29218,6 +30855,10 @@
       },
       "engines": {
         "node": ">= 4"
+      },
+      "peerDependencies": {
+        "prettier": "^1.9.0 || ^2.0.0",
+        "tslint": "^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/tslint-plugin-prettier/node_modules/tslib": {
@@ -29248,6 +30889,9 @@
       "dev": true,
       "dependencies": {
         "tslib": "^1.8.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
       }
     },
     "node_modules/tsutils/node_modules/tslib": {
@@ -29308,6 +30952,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -29445,6 +31092,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
@@ -29539,6 +31187,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
       "dev": true
     },
     "node_modules/url": {
@@ -29601,6 +31250,9 @@
         "es-abstract": "^1.17.2",
         "has-symbols": "^1.0.1",
         "object.getownpropertydescriptors": "^2.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/util.promisify/node_modules/es-abstract": {
@@ -29623,6 +31275,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/util/node_modules/inherits": {
@@ -29694,7 +31349,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.4.tgz",
       "integrity": "sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/verror": {
       "version": "1.10.0",
@@ -29760,7 +31419,9 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "dev": true
+      "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+      "dev": true,
+      "hasInstallScript": true
     },
     "node_modules/wait-port": {
       "version": "0.2.9",
@@ -29800,11 +31461,11 @@
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
+        "chokidar": "^3.4.1",
         "watchpack-chokidar2": "^2.0.1"
       }
     },
@@ -29891,13 +31552,13 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
       "dev": true,
       "optional": true,
       "dependencies": {
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -29906,6 +31567,9 @@
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.2.1",
         "upath": "^1.1.1"
+      },
+      "optionalDependencies": {
+        "fsevents": "^1.2.7"
       }
     },
     "node_modules/watchpack-chokidar2/node_modules/fill-range": {
@@ -29941,7 +31605,9 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -30146,6 +31812,18 @@
       },
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        },
+        "webpack-command": {
+          "optional": true
+        }
       }
     },
     "node_modules/webpack-dev-middleware": {
@@ -30162,6 +31840,9 @@
       },
       "engines": {
         "node": ">= 6"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
       }
     },
     "node_modules/webpack-dev-middleware/node_modules/mime": {
@@ -30221,6 +31902,14 @@
       },
       "engines": {
         "node": ">= 6.11.5"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
       }
     },
     "node_modules/webpack-dev-server/node_modules/anymatch": {
@@ -30291,6 +31980,7 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
       "dev": true,
       "dependencies": {
         "anymatch": "^2.0.0",
@@ -30340,7 +32030,9 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -30523,6 +32215,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
@@ -30599,6 +32292,15 @@
       },
       "engines": {
         "node": ">=4"
+      },
+      "peerDependencies": {
+        "html-webpack-plugin": ">= 2.21.0 < 5",
+        "webpack": ">= 1.12.11 < 6"
+      },
+      "peerDependenciesMeta": {
+        "html-webpack-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/webpack-subresource-integrity/node_modules/source-map": {
@@ -30961,6 +32663,9 @@
       },
       "engines": {
         "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
       }
     },
     "node_modules/webpack/node_modules/to-regex-range": {
@@ -31163,6 +32868,9 @@
       "dev": true,
       "dependencies": {
         "loader-utils": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": ">= 4"
       }
     },
     "node_modules/worker-plugin/node_modules/json5": {
@@ -31465,6 +33173,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zone.js": {
@@ -37650,13 +39361,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -40585,7 +42298,8 @@
           "version": "7.4.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
           "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "yargs": {
           "version": "15.4.1",
@@ -41760,7 +43474,8 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz",
       "integrity": "sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "cjs-module-lexer": {
       "version": "0.6.0",
@@ -41941,13 +43656,15 @@
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-9.0.0.tgz",
           "integrity": "sha512-ctjwuntPfZZT2mNj2NDIVu51t9cvbhl/16epc5xEwyzyDt76pX9UgwvY+MbXrf/C/FWwdtmNtfP698BKI+9leQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "@angular/core": {
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/@angular/core/-/core-9.0.0.tgz",
           "integrity": "sha512-6Pxgsrf0qF9iFFqmIcWmjJGkkCaCm6V5QNnxMy2KloO3SDq6QuMVRbN9RtC8Urmo25LP+eZ6ZgYqFYpdD8Hd9w==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "source-map": {
           "version": "0.5.7",
@@ -42717,7 +44434,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
       "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -45399,7 +47117,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ieee754": {
       "version": "1.2.1",
@@ -47908,7 +49627,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-preset-angular": {
       "version": "8.3.2",
@@ -49089,7 +50809,8 @@
           "version": "7.5.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.1.tgz",
           "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -51694,25 +53415,29 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
       "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
       "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
       "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
       "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-import": {
       "version": "14.0.0",
@@ -51843,7 +53568,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -51878,7 +53604,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
       "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.0.1",

--- a/src/app/core/services/aql/test/aql.service.spec.ts
+++ b/src/app/core/services/aql/test/aql.service.spec.ts
@@ -77,8 +77,10 @@ describe('AqlService', () => {
     beforeEach(() => {
       jest.spyOn(httpClient, 'get').mockImplementation(() => throwError('Error'))
       jest.spyOn(service, 'handleError')
-      service.cacheTime = 0
       service.getAllObservable$ = undefined
+      const date = new Date()
+      date.setMinutes(date.getMinutes() - 1)
+      service.getAllTimeStamp = date
     })
 
     it('should call the api - with error', async () => {
@@ -120,13 +122,13 @@ describe('AqlService', () => {
     })
 
     it('should return with a single aql found in memory', async () => {
-      const preFillMemory = await service.getAll().toPromise()
+      await service.getAll().toPromise()
       const result = await service.get(1).toPromise()
       expect(result.id).toEqual(1)
     })
 
     it('should return with an not found error when not found', async () => {
-      const result = await service
+      await service
         .get(123)
         .toPromise()
         .catch((error) => {


### PR DESCRIPTION
## Changes

This PR adds a cache mechanism to the getAll of AQL service to prevent duplicated requests agains the AQL backend done in project editor or search using the cohort-builder feature.

## Related issues

Defect: [NUM-1712: AQL query is not shown in details](https://jira.vitagroup.ag/browse/NUM-1712)
Sub-Task: [NUM-1724: FE | Prevent Search page from sending multiple GET AQLs](https://jira.vitagroup.ag/browse/NUM-1724)