### PR TITLE
fix(NUM-1715): Appends code_string to defining_code in aqb where

### DIFF
--- a/src/app/modules/search/components/manager-data-explorer/manager-data-explorer.component.html
+++ b/src/app/modules/search/components/manager-data-explorer/manager-data-explorer.component.html
@@ -23,6 +23,7 @@
     class="num-margin-b-60"
     (singleClick)="getData()"
     [isDisabled]="!isAqlPrepared"
+    data-test="manager-data-explorer__retrieval-button"
     >{{ 'BUTTON.GET_DATA' | translate }}</num-button
   >
 

--- a/src/app/shared/models/aqb/aqb-where-item-ui.model.ts
+++ b/src/app/shared/models/aqb/aqb-where-item-ui.model.ts
@@ -64,7 +64,7 @@ export class AqbWhereItemUiModel {
     this.name = item.name || item.archetypeId
     this.givenName = item.name || item.archetypeId
     this.rmType = item.rmType
-    this.aqlPath = item.aqlPath || ''
+    this.aqlPath = this.configurePath(item.aqlPath || '')
     this.humanReadablePath = item.humanReadablePath
     this.compositionReferenceId = compositionReferenceId
     this.archetypeReferenceId = archetypeReferenceId
@@ -74,6 +74,10 @@ export class AqbWhereItemUiModel {
     this.isParameterType = false
     this.configureOptions()
     this.configureInput()
+  }
+
+  private configurePath(aqlPath: string): string {
+    return aqlPath.endsWith('defining_code') ? aqlPath + '/code_string' : aqlPath
   }
 
   configureOptions(): void {


### PR DESCRIPTION
This PR fixes the issue that DV_CODED_TEXT was not useable by appending 'code_string' to aql-paths ending with 'defining_code' in the aql-builder where element