### PR TITLE
feat(NUM-1737): Adds Cookie-Dialog before login

### DIFF
--- a/src/app/layout/components/side-menu/constants.ts
+++ b/src/app/layout/components/side-menu/constants.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2021 Vitagroup AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DialogConfirmationComponent } from 'src/app/shared/components/dialog-confirmation/dialog-confirmation.component'
+import { DialogConfig } from 'src/app/shared/models/dialog/dialog-config.interface'
+import { DialogSize } from 'src/app/shared/models/dialog/dialog-size.enum'
+
+export const COOKIE_DIALOG_CONFIG: DialogConfig = {
+  isDecision: true,
+  title: 'LEGAL.COOKIE_WARNING_TITLE',
+  confirmButtonText: 'BUTTON.ACCEPT',
+  cancelButtonText: 'BUTTON.DECLINE',
+  dialogSize: DialogSize.Small,
+  dialogContentComponent: DialogConfirmationComponent,
+  dialogContentPayload: 'LEGAL.COOKIE_WARNING_CONTENT',
+}

--- a/src/app/layout/components/side-menu/side-menu.component.ts
+++ b/src/app/layout/components/side-menu/side-menu.component.ts
@@ -25,6 +25,8 @@ import {
 import { AuthService } from 'src/app/core/auth/auth.service'
 import { Subscription } from 'rxjs'
 import { ContentService } from '../../../core/services/content/content.service'
+import { DialogService } from 'src/app/core/services/dialog/dialog.service'
+import { COOKIE_DIALOG_CONFIG } from './constants'
 
 @Component({
   selector: 'num-side-menu',
@@ -41,7 +43,11 @@ export class SideMenuComponent implements OnInit, OnDestroy {
 
   @Output() toggleSideMenu = new EventEmitter()
 
-  constructor(private authService: AuthService, public contentService: ContentService) {}
+  constructor(
+    private authService: AuthService,
+    public contentService: ContentService,
+    private dialogService: DialogService
+  ) {}
 
   ngOnInit(): void {
     this.subscriptions.add(
@@ -72,10 +78,19 @@ export class SideMenuComponent implements OnInit, OnDestroy {
     if (item.routeTo === '#logout') {
       this.authService.logout()
     } else if (item.routeTo === '#login') {
-      this.authService.login()
+      this.handleLoginWithDialog()
     }
     const target = $event.currentTarget as HTMLElement
     target.blur()
     this.toggleSideMenu.emit()
+  }
+
+  handleLoginWithDialog(): void {
+    const dialogRef = this.dialogService.openDialog(COOKIE_DIALOG_CONFIG)
+    dialogRef.afterClosed().subscribe((confirmResult: boolean | undefined) => {
+      if (confirmResult === true) {
+        this.authService.login()
+      }
+    })
   }
 }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -65,7 +65,9 @@
   "LEGAL": {
     "DISCLOSURE": "Impressum",
     "DATAPROTECTION": "Datenschutz",
-    "CONTACT": "Kontakt"
+    "CONTACT": "Kontakt",
+    "COOKIE_WARNING_TITLE": "Notwendige Cookies",
+    "COOKIE_WARNING_CONTENT": "Diese Website setzt technisch notwendige Cookies (Sitzungs-Cookies) auf Ihrem Computer, die für grundlegende Funktionen der Website erforderlich sind."
   },
   "FILTER_CHIP": {
     "MY_AQLS": "Meine",
@@ -207,6 +209,8 @@
     "SAVE": "Speichern",
     "CANCEL": "Abbrechen",
     "DISCARD": "Änderungen verwerfen",
+    "ACCEPT": "Akzeptieren",
+    "DECLINE": "Ablehnen",
     "BACK": "Zurück",
     "CLEAR_ENTRY": "Eingabe löschen",
     "REQUEST_APPROVAL": "Genehmigung anfragen",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -65,7 +65,9 @@
   "LEGAL": {
     "DISCLOSURE": "Disclosure",
     "DATAPROTECTION": "Data Protection",
-    "CONTACT": "Contact"
+    "CONTACT": "Contact",
+    "COOKIE_WARNING_TITLE": "Essential Cookies",
+    "COOKIE_WARNING_CONTENT": "This website sets technically essential cookies (session cookies) at your computer which are required for the basic functionality of the website."
   },
   "FILTER_CHIP": {
     "MY_AQLS": "My AQLs",
@@ -206,6 +208,8 @@
     "SAVE": "Save",
     "CANCEL": "Cancel",
     "DISCARD": "Discard changes",
+    "ACCEPT": "Accept",
+    "DECLINE": "Decline",
     "BACK": "Back",
     "CLEAR_ENTRY": "Clear entry",
     "REQUEST_APPROVAL": "Request approval",

--- a/src/styles/custom-material/styles/_typography.themed.scss
+++ b/src/styles/custom-material/styles/_typography.themed.scss
@@ -34,6 +34,7 @@
 
       &.decision-dialog {
         text-align: center;
+        width: 100%;
       }
     }
   }


### PR DESCRIPTION
**Task-Description:**
The user gets a dialog to accept cookies before he is redirected to Keycloak.
If the user aborts, the action is stopped and he stays on the Welcome-Page (and can start the action again).