### PR TITLE
fix(NUM-1736) Add create project button

### DIFF
--- a/src/app/core/constants/navigation.ts
+++ b/src/app/core/constants/navigation.ts
@@ -63,6 +63,7 @@ export const mainNavItems: INavItem[] = [
         routeTo: 'projects/new/editor',
         id: 'editor',
         translationKey: 'NAVIGATION.PROJECTS_EDITOR',
+        disabled: true,
       },
     ],
   },

--- a/src/app/modules/projects/components/projects/projects.component.html
+++ b/src/app/modules/projects/components/projects/projects.component.html
@@ -18,4 +18,14 @@
 
 <p class="num-margin-b-40"></p>
 
+<section
+  role="presentation"
+  class="num-margin-b-40"
+  *numUserHasRole="[availableRoles.StudyCoordinator]"
+>
+  <num-button icon="plus" routerLink="./new/editor" id="project-create-button">{{
+    'BUTTON.PROJECT_CREATE' | translate
+  }}</num-button>
+</section>
+
 <num-projects-table></num-projects-table>

--- a/src/app/modules/projects/components/projects/projects.component.spec.ts
+++ b/src/app/modules/projects/components/projects/projects.component.spec.ts
@@ -17,10 +17,15 @@
 import { Component } from '@angular/core'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
+import { RouterTestingModule } from '@angular/router/testing'
 import { TranslateModule } from '@ngx-translate/core'
-import { of } from 'rxjs'
+import { of, Subject } from 'rxjs'
+import { AuthService } from 'src/app/core/auth/auth.service'
 import { ProjectService } from 'src/app/core/services/project/project.service'
 import { MaterialModule } from 'src/app/layout/material/material.module'
+import { AvailableRoles } from 'src/app/shared/models/available-roles.enum'
+import { IAuthUserInfo } from 'src/app/shared/models/user/auth-user-info.interface'
+import { SharedModule } from 'src/app/shared/shared.module'
 
 import { ProjectsComponent } from './projects.component'
 
@@ -35,14 +40,32 @@ describe('ProjectsComponent', () => {
     getAll: () => of(),
   } as unknown) as ProjectService
 
+  const userInfoSubject$ = new Subject<IAuthUserInfo>()
+  const authService = ({
+    get isLoggedIn(): boolean {
+      return true
+    },
+    userInfoObservable$: userInfoSubject$.asObservable(),
+  } as unknown) as AuthService
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ProjectsComponent, ProjectsTableStubComponent],
-      imports: [MaterialModule, BrowserAnimationsModule, TranslateModule.forRoot()],
+      imports: [
+        BrowserAnimationsModule,
+        MaterialModule,
+        RouterTestingModule,
+        SharedModule,
+        TranslateModule.forRoot(),
+      ],
       providers: [
         {
           provide: ProjectService,
           useValue: projectService,
+        },
+        {
+          provide: AuthService,
+          useValue: authService,
         },
       ],
     }).compileComponents()
@@ -51,6 +74,7 @@ describe('ProjectsComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ProjectsComponent)
     component = fixture.componentInstance
+    userInfoSubject$.next({ sub: '', groups: [AvailableRoles.StudyCoordinator] })
     fixture.detectChanges()
   })
 

--- a/src/app/modules/projects/components/projects/projects.component.ts
+++ b/src/app/modules/projects/components/projects/projects.component.ts
@@ -16,6 +16,7 @@
 
 import { Component, OnInit } from '@angular/core'
 import { ProjectService } from 'src/app/core/services/project/project.service'
+import { AvailableRoles } from 'src/app/shared/models/available-roles.enum'
 
 @Component({
   selector: 'num-projects',
@@ -23,6 +24,7 @@ import { ProjectService } from 'src/app/core/services/project/project.service'
   styleUrls: ['./projects.component.scss'],
 })
 export class ProjectsComponent implements OnInit {
+  availableRoles = AvailableRoles
   constructor(private projectService: ProjectService) {}
   ngOnInit(): void {
     this.projectService.getAll().subscribe()

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -258,7 +258,8 @@
     "MORE_INFO": "Mehr Informationen",
     "NEXT_STEP": "Nächster Schritt",
     "PREVIOUS_STEP": "Schritt zurück",
-    "START_DATA_RETRIEVAL": "Datenabruf starten"
+    "START_DATA_RETRIEVAL": "Datenabruf starten",
+    "PROJECT_CREATE": "Projekt erstellen"
   },
   "PROJECT": {
     "DEFINE_COHORT": "Kohorte definieren",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -257,7 +257,8 @@
     "MORE_INFO": "More Info",
     "NEXT_STEP": "Next Step",
     "PREVIOUS_STEP": "Previous Step",
-    "START_DATA_RETRIEVAL": "Data Retrieval"
+    "START_DATA_RETRIEVAL": "Data Retrieval",
+    "PROJECT_CREATE": "Create project"
   },
   "PROJECT": {
     "DEFINE_COHORT": "Define Cohort",


### PR DESCRIPTION
## Changes

This PR adds a create project button to the project overview table that can only be seen by Project leads. Also the tab for editing a project is disabled for user clicks now.

## Acceptance Criteria

A Project approver can only open projects in project editor by clicking them from the project overview list
the click on tab "project editor" should be disabled, if the user doesn't have the role "project lead"

## Related issues

Defect: [NUM-1736: Project editor tab is clickable for Project approver](https://jira.vitagroup.ag/browse/NUM-1736)