### PR TITLE
fix(NUM-1735): Manager role only to be set by super admin

### DIFF
--- a/src/app/modules/user-management/components/add-user-roles/add-user-roles.component.spec.ts
+++ b/src/app/modules/user-management/components/add-user-roles/add-user-roles.component.spec.ts
@@ -102,9 +102,10 @@ describe('AddUserRolesComponent', () => {
       userProfileSubject$.next(mockUserProfile1)
     })
 
-    it('should not include the roles SuperAdmin and Content Admin as dataSource.data', () => {
+    it('should not include the roles Manager, SuperAdmin and Content Admin as dataSource.data', () => {
       expect(component.dataSource.data).not.toContain('SUPER_ADMIN')
       expect(component.dataSource.data).not.toContain('CONTENT_ADMIN')
+      expect(component.dataSource.data).not.toContain('MANAGER')
     })
   })
 
@@ -117,10 +118,11 @@ describe('AddUserRolesComponent', () => {
       fixture.detectChanges()
       userProfileSubject$.next(mockUserProfile3)
     })
-    it('should include the roles SuperAdmin and Content Admin in dataSource.data', () => {
+    it('should include the roles Manager, SuperAdmin and Content Admin in dataSource.data', () => {
       userProfileSubject$.next(mockUserProfile3)
       expect(component.dataSource.data).toContain('SUPER_ADMIN')
       expect(component.dataSource.data).toContain('CONTENT_ADMIN')
+      expect(component.dataSource.data).toContain('MANAGER')
     })
   })
 })

--- a/src/app/modules/user-management/components/add-user-roles/add-user-roles.component.ts
+++ b/src/app/modules/user-management/components/add-user-roles/add-user-roles.component.ts
@@ -63,7 +63,10 @@ export class AddUserRolesComponent implements OnInit, OnDestroy {
     const availableRoles = Object.values(AvailableRoles)
     if (!this.userProfile.roles.includes(AvailableRoles.SuperAdmin)) {
       this.dataSource.data = availableRoles.filter(
-        (role) => role !== AvailableRoles.SuperAdmin && role !== AvailableRoles.ContentAdmin
+        (role) =>
+          role !== AvailableRoles.SuperAdmin &&
+          role !== AvailableRoles.ContentAdmin &&
+          role !== AvailableRoles.Manager
       )
     } else {
       this.dataSource.data = availableRoles


### PR DESCRIPTION
This PR fixes the Issue that the manager role could be set by the organisation admin. It's now limited to the super admin