### PR TITLE
feat(NUM-1756): Adds error message for aql parameter resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog][keep a changelog] and this project adh
 - Resolving of pseudonyms to patient ids ([#276])
 - Simplification of Data-Retrieval for the manager ([#278])
 - Flag for default configuration to the data retrieval in the data-explorer ([#279])
+- Error message in case a parameter can't be resolved in the cohort builder ([#282])
 
 ### Changed
 
@@ -554,3 +555,4 @@ The format is based on [Keep a Changelog][keep a changelog] and this project adh
 [#279]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/279
 [#280]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/280
 [#281]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/281
+[#282]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/282

--- a/src/app/modules/cohort-builder/components/aql-connector-item/aql-connector-item.component.html
+++ b/src/app/modules/cohort-builder/components/aql-connector-item/aql-connector-item.component.html
@@ -17,7 +17,14 @@
 <section role="region" fxLayout="row wrap" fxLayoutGap="15px" fxLayoutAlign="start start">
   <div>{{ aql.name }}</div>
 
-  <div fxLayout="column" fxLayoutGap="8px">
+  <ng-template #parameterError>
+    <mat-hint class="parameter-error">
+      <fa-icon [fixedWidth]="true" class="num-fc--w" icon="exclamation-circle"></fa-icon>
+      {{ 'QUERIES.PARAMETER_ERROR' | translate }}</mat-hint
+    >
+  </ng-template>
+
+  <div fxLayout="column" fxLayoutGap="8px" *ngIf="!hasParameterError; else parameterError">
     <div *ngFor="let parameter of aql.parameters" fxLayoutGap="8px" fxLayout="row">
       <mat-form-field
         appearance="outline"

--- a/src/app/modules/cohort-builder/components/aql-connector-item/aql-connector-item.component.scss
+++ b/src/app/modules/cohort-builder/components/aql-connector-item/aql-connector-item.component.scss
@@ -33,3 +33,7 @@
 mat-checkbox {
   align-self: center;
 }
+
+.parameter-error {
+  margin: 10px 0 0 0;
+}

--- a/src/app/modules/cohort-builder/components/aql-connector-item/aql-connector-item.component.spec.ts
+++ b/src/app/modules/cohort-builder/components/aql-connector-item/aql-connector-item.component.spec.ts
@@ -20,7 +20,7 @@ import { FormsModule } from '@angular/forms'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing'
 import { TranslateModule } from '@ngx-translate/core'
-import { of } from 'rxjs'
+import { of, throwError } from 'rxjs'
 import { AqlParameterService } from 'src/app/core/services/aql-parameter/aql-parameter.service'
 import { MaterialModule } from 'src/app/layout/material/material.module'
 import { AqlParameterValueType } from 'src/app/shared/models/aql/aql-parameter-value-type.enum'
@@ -141,6 +141,14 @@ describe('AqlConnectorItemComponent', () => {
       if (optionKeys.length) {
         expect(component.aql.parameters[0].value).toEqual(optionKeys[0])
       }
+    })
+
+    it('should flag the item with a parameter error when one parameter could not be resolved', () => {
+      jest.spyOn(mockAqlParameterService, 'getValues').mockImplementation(() => throwError('Error'))
+      component.aql = new AqlUiModel(mockAql3, false, testcases[0].parameters)
+
+      fixture.detectChanges()
+      expect(component.hasParameterError).toBeTruthy()
     })
   })
 

--- a/src/app/shared/models/aql/aql-ui.model.ts
+++ b/src/app/shared/models/aql/aql-ui.model.ts
@@ -42,6 +42,7 @@ export class AqlUiModel implements ConnectorMainNodeUi<ICohortGroupApi> {
   purpose: string
   use: string
   owner?: IUser | null
+  hasParameterError: boolean
 
   constructor(
     aql: Partial<IAqlApi>,
@@ -83,26 +84,33 @@ export class AqlUiModel implements ConnectorMainNodeUi<ICohortGroupApi> {
     })
 
     this.parameters.forEach((parameter) => {
-      const parameterPathRegex = new RegExp('\\S+\\s+\\S+\\s+\\' + parameter.nameWithDollar, 'gmi')
-      const fullParameterPath = this.query.match(parameterPathRegex)[0]
-      const fullParameterPathSplitted = fullParameterPath.split(' ')
-      const archetypeReferenceId = fullParameterPathSplitted[0].match(/\w+/)[0]
-      const archetypeIdRegex = new RegExp(archetypeReferenceId + '\\[(.+?)(?=s*])')
+      try {
+        const parameterPathRegex = new RegExp(
+          '\\S+\\s+\\S+\\s+\\' + parameter.nameWithDollar,
+          'gmi'
+        )
+        const fullParameterPath = this.query.match(parameterPathRegex)[0]
+        const fullParameterPathSplitted = fullParameterPath.split(' ')
+        const archetypeReferenceId = fullParameterPathSplitted[0].match(/\w+/)[0]
+        const archetypeIdRegex = new RegExp(archetypeReferenceId + '\\[(.+?)(?=s*])')
 
-      parameter.operator =
-        fullParameterPathSplitted[1] in AqlParameterOperator
-          ? (fullParameterPathSplitted[1] as AqlParameterOperator)
-          : AqlParameterOperator['!=']
-      parameter.path = fullParameterPathSplitted[0].split(archetypeReferenceId)[1]
-      parameter.archetypeId = this.query.match(archetypeIdRegex)[0].split('[')[1]
+        parameter.operator =
+          fullParameterPathSplitted[1] in AqlParameterOperator
+            ? (fullParameterPathSplitted[1] as AqlParameterOperator)
+            : AqlParameterOperator['!=']
+        parameter.path = '/' + fullParameterPathSplitted[0].split(archetypeReferenceId + '/')[1]
+        parameter.archetypeId = this.query.match(archetypeIdRegex)[0].split('[')[1]
 
-      const pathWithInjectedPlaceholder = fullParameterPath
-        .replace(parameter.nameWithDollar, parameter.nameWithDollar + this.NAME_SUFFIX)
-        .replace(parameter.operator, parameter.nameWithDollar + this.OPERATOR_SUFFIX)
+        const pathWithInjectedPlaceholder = fullParameterPath
+          .replace(parameter.nameWithDollar, parameter.nameWithDollar + this.NAME_SUFFIX)
+          .replace(parameter.operator, parameter.nameWithDollar + this.OPERATOR_SUFFIX)
 
-      this.queryWithOperatorPlaceholder = (
-        this.queryWithOperatorPlaceholder ? this.queryWithOperatorPlaceholder : this.query
-      ).replace(fullParameterPath, pathWithInjectedPlaceholder)
+        this.queryWithOperatorPlaceholder = (
+          this.queryWithOperatorPlaceholder ? this.queryWithOperatorPlaceholder : this.query
+        ).replace(fullParameterPath, pathWithInjectedPlaceholder)
+      } catch (_) {
+        this.hasParameterError = true
+      }
     })
   }
 

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -83,6 +83,7 @@
     "COPY_CLIPBOARD_SUCCESS": "Patienten-Id wurde in die Zwischenablage kopiert"
   },
   "QUERIES": {
+    "PARAMETER_ERROR": "Die Parameter dieses Kriteriums können nicht verwendet werden",
     "INFO_DIALOG_TITLE": "Informationen zum Kriterium",
     "AS": "als",
     "CREATE_QUERY": "Kriterium erstellen",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -83,6 +83,7 @@
     "COPY_CLIPBOARD_SUCCESS": "Copied patient-id to clipboard"
   },
   "QUERIES": {
+    "PARAMETER_ERROR": "The parameters of this criterium are not usable",
     "INFO_DIALOG_TITLE": "Information about the Criteria",
     "AS": "as",
     "CREATE_QUERY": "Create",


### PR DESCRIPTION
**Story-Description:**
If the Parameter endpoint responses with an error (400, 500), the AQL query is not usable. So the user should be informed about it.

DE: "Die Parameter dieses Kriteriums können nicht verwendet werden"
EN: "The parameters of this criterium are not usable"