### PR TITLE
fix(NUM-1730): Data Retrieval default configuration order

### DIFF
--- a/src/app/modules/data-explorer/components/data-explorer/data-explorer.component.ts
+++ b/src/app/modules/data-explorer/components/data-explorer/data-explorer.component.ts
@@ -221,8 +221,8 @@ export class DataExplorerComponent implements OnInit, OnDestroy {
     this.selectedTemplateIds = confirmResult.selectedTemplateIds
     this.compiledQuery = confirmResult.result
 
-    this.getDataSet()
     this.configuration = DataExplorerConfigurations.Custom
+    this.getDataSet()
   }
 
   resetAqbModel(): void {


### PR DESCRIPTION
**Story-Description:**
As a Manager I want to receive data from different templates splitted into different tables, so that I can easily find the data of interest

This PR fixes the sending of the flag