### PR TITLE
feat(NUM-1730): Adds defaultConfig flag for data export of researcher

### DIFF
--- a/src/app/core/services/project/project.service.spec.ts
+++ b/src/app/core/services/project/project.service.spec.ts
@@ -326,9 +326,9 @@ describe('ProjectService', () => {
       const id = 1
       const format = 'csv'
       jest.spyOn(httpClient, 'post').mockImplementation(() => of(projectCommentMock1))
-      service.exportFile(id, query, format).subscribe()
+      service.exportFile(id, query, format, true).subscribe()
       expect(httpClient.post).toHaveBeenCalledWith(
-        `${baseUrl}/${id}/export?format=csv`,
+        `${baseUrl}/${id}/export?format=csv&defaultConfiguration=true`,
         { query },
         { responseType: 'blob' as 'json' }
       )

--- a/src/app/core/services/project/project.service.ts
+++ b/src/app/core/services/project/project.service.ts
@@ -158,10 +158,15 @@ export class ProjectService {
       .pipe(catchError(this.handleError))
   }
 
-  exportFile(id: number, query: string, format: string): Observable<string> {
+  exportFile(
+    id: number,
+    query: string,
+    format: string,
+    defaultConfiguration: boolean
+  ): Observable<string> {
     return this.httpClient
       .post<string>(
-        `${this.baseUrl}/${id}/export?format=${format}`,
+        `${this.baseUrl}/${id}/export?format=${format}&defaultConfiguration=${defaultConfiguration}`,
         { query },
         { responseType: (format === 'json' ? 'text' : 'blob') as 'json' }
       )

--- a/src/app/modules/data-explorer/components/data-explorer/data-explorer.component.ts
+++ b/src/app/modules/data-explorer/components/data-explorer/data-explorer.component.ts
@@ -275,26 +275,29 @@ export class DataExplorerComponent implements OnInit, OnDestroy {
     if (!this.compiledQuery) return
 
     this.isExportLoading = true
+    const defaultConfiguration = this.configuration === DataExplorerConfigurations.Default
 
     this.subscriptions.add(
-      this.projectService.exportFile(this.project.id, this.compiledQuery.q, format).subscribe(
-        (response) => {
-          downloadFile(this.project.id, format, response)
-          this.isExportLoading = false
-        },
-        () => {
-          this.isExportLoading = false
+      this.projectService
+        .exportFile(this.project.id, this.compiledQuery.q, format, defaultConfiguration)
+        .subscribe(
+          (response) => {
+            downloadFile(this.project.id, format, response)
+            this.isExportLoading = false
+          },
+          () => {
+            this.isExportLoading = false
 
-          const messageConfig: IToastMessageConfig = {
-            ...EXPORT_ERROR,
-            messageParameters: {
-              format: format.toUpperCase(),
-            },
+            const messageConfig: IToastMessageConfig = {
+              ...EXPORT_ERROR,
+              messageParameters: {
+                format: format.toUpperCase(),
+              },
+            }
+
+            this.toastMessageService.openToast(messageConfig)
           }
-
-          this.toastMessageService.openToast(messageConfig)
-        }
-      )
+        )
     )
   }
 }


### PR DESCRIPTION
**Story-Description:**
As a Manager I want to receive data from different templates splitted into different tables, so that I can easily find the data of interest

This PR adds the defaultConfiguration flag to the export functionality 