### PR TITLE
fix(NUM-1782): AQL filter after deletion

### DIFF
--- a/src/app/modules/aqls/components/aql-table/aql-table.component.ts
+++ b/src/app/modules/aqls/components/aql-table/aql-table.component.ts
@@ -162,7 +162,7 @@ export class AqlTableComponent extends SortableTable<IAqlApi> implements AfterVi
     dialogRef.afterClosed().subscribe((confirmResult) => {
       if (confirmResult === true) {
         this.delete(id).then(() => {
-          this.aqlService.getAll().subscribe((aqls) => this.handleData(aqls))
+          this.aqlService.getAll().subscribe()
         })
       }
     })


### PR DESCRIPTION
This PR fixes the Issue that the AQLs Table was not showing filtered AQLS after deletion of an AQL