### PR TITLE
feat(NUM-1786): Handles active group setting after deletion

### DIFF
--- a/src/app/modules/cohort-builder/components/aql-connector-group/aql-connector-group.component.html
+++ b/src/app/modules/cohort-builder/components/aql-connector-group/aql-connector-group.component.html
@@ -82,7 +82,7 @@
       [ngClass]="{
         'group--last': i === cohortGroup.children.length - 1
       }"
-      (delete)="deleteChild($event)"
+      (delete)="deleteChildGroup($event, i)"
       data-test="cohort-builder__group"
     ></num-aql-connector-group>
 
@@ -95,7 +95,7 @@
       *ngIf="child.type === connectorNodeType.Aql"
       [aql]="child"
       [isDisabled]="isDisabled"
-      (deleteItem)="deleteChild(i)"
+      (deleteItem)="deleteChildItem(i)"
       role="listitem"
       fxLayout="row"
       fxLayoutAlign="space-between start"

--- a/src/app/modules/cohort-builder/components/aql-connector-group/aql-connector-group.component.ts
+++ b/src/app/modules/cohort-builder/components/aql-connector-group/aql-connector-group.component.ts
@@ -167,12 +167,19 @@ export class AqlConnectorGroupComponent implements OnInit, OnChanges, OnDestroy 
     this.enumerateGroupsDebounced()
   }
 
-  deleteChild(index: number): void {
+  deleteChildItem(index: number): void {
     this.cohortGroup.children.splice(index, 1)
+  }
+
+  deleteChildGroup(wasActive: boolean, index: number): void {
+    this.cohortGroup.children.splice(index, 1)
+    if (wasActive) {
+      this.setDestination()
+    }
     this.enumerateGroupsDebounced()
   }
 
   deleteSelf(): void {
-    this.delete.emit(this.index)
+    this.delete.emit(this.isActive)
   }
 }


### PR DESCRIPTION
**Story-Description:**
After deleting a subgroup the parent group of the deleted subgroup is selected