### PR TITLE
feat(NUM-1792) Change button labels & add help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog][keep a changelog] and this project adh
 
 ## [Unreleased]
 
+### Changed
+
+- Data Explorer: Add help text and change labels of configurate result ([#302])
+- Data Explorer: Change english hint to use button to retreive data first
+
 ### Fixed
 
 - Project editor: Hide edit button from approvers ([#291])
@@ -576,3 +581,12 @@ The format is based on [Keep a Changelog][keep a changelog] and this project adh
 [#291]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/291
 [#292]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/292
 [#293]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/293
+[#294]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/294
+[#295]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/295
+[#296]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/296
+[#297]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/297
+[#298]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/298
+[#299]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/299
+[#300]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/300
+[#301]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/301
+[#302]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/302

--- a/src/app/layout/font-awesome-icons.ts
+++ b/src/app/layout/font-awesome-icons.ts
@@ -51,6 +51,7 @@ import {
   faUndo,
   faInfoCircle,
   faClipboard,
+  faQuestionCircle,
 } from '@fortawesome/free-solid-svg-icons'
 
 import { faNewspaper, faCheckCircle, faEye, faHospital } from '@fortawesome/free-regular-svg-icons'
@@ -92,6 +93,7 @@ export const FONT_AWESOME_SOLID_ICONS = [
   faUndo,
   faInfoCircle,
   faClipboard,
+  faQuestionCircle,
 ]
 
 export const FONT_AWESOME_REGULAR_ICONS = [faNewspaper, faCheckCircle, faEye, faHospital]

--- a/src/app/modules/data-explorer/components/data-explorer/data-explorer.component.html
+++ b/src/app/modules/data-explorer/components/data-explorer/data-explorer.component.html
@@ -32,6 +32,11 @@
     [generalInfoData]="generalInfoData"
   ></num-project-editor-accordion>
 
+  <section role="presentation">
+    <h3>{{ 'DATA_EXPLORER.HEADLINE_RETREIVE_SECTION' | translate }}</h3>
+    <p class="num-margin-b-20">{{ 'DATA_EXPLORER.INTRODUCTION_RETREIVE_SECTION' | translate }}</p>
+  </section>
+
   <section
     role="presentation"
     fxLayout="row wrap"
@@ -47,7 +52,7 @@
       >{{ 'BUTTON.GET_DATA' | translate }}</num-button
     >
 
-    <div fxLayoutGap="20px">
+    <div fxLayoutGap="20px" class="num-margin-b-10">
       <num-button
         [isDisabled]="!isCompositionsFetched || isDataSetLoading"
         type="secondary"

--- a/src/app/modules/data-explorer/components/data-explorer/data-explorer.component.scss
+++ b/src/app/modules/data-explorer/components/data-explorer/data-explorer.component.scss
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 :host {
   width: 100%;
   margin: 0 0 60px 0;

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -257,8 +257,8 @@
     "EXECUTE": "Ausführen",
     "GET_DATA": "Daten abrufen",
     "APPLY_CONFIGURATION": "Konfiguration übernehmen",
-    "CUSTOMIZE_CONFIGURATION": "Konfiguration anpassen",
-    "RESET_CUSTOMIZATION": "Konfiguration zurücksetzen",
+    "CUSTOMIZE_CONFIGURATION": "Daten filtern",
+    "RESET_CUSTOMIZATION": "Filter zurücksetzen",
     "CREATE_ORGANIZATION": "Organisation erstellen",
     "UPDATE_NAME": "Name aktualisieren",
     "DETERMINE": "Ermitteln",
@@ -400,7 +400,9 @@
     "QUERY_BUILDER_DIALOG_HEADER": "Konfiguration der Datenabfrage bearbeiten",
     "RESULT_SET_ERROR": "Die Ergebnisse konnte nicht geladen werden. Bitte passen Sie die Konfiguration an und versuchen es erneut.",
     "EXPORT": "{{format}} Exportieren",
-    "EXPORT_ERROR": "Fehler beim Versuch die {{format}} Datei zu exportieren, bitte versuchen Sie es später noch einmal."
+    "EXPORT_ERROR": "Fehler beim Versuch die {{format}} Datei zu exportieren, bitte versuchen Sie es später noch einmal.",
+    "HEADLINE_RETREIVE_SECTION": "Datenabruf",
+    "INTRODUCTION_RETREIVE_SECTION": "Rufen Sie Daten ab, schränken Sie die Ergebnismenge mit temporären Filtern ein oder entfernen Sie zuvor definierte temporäre Filter. Bitte beachten Sie: Bei der Filter-Definition können ungewollt Kreuzprodukte als Resultat entstehen."
   },
   "USER_MANAGEMENT": {
     "NEW_USERS_HEADER": "Alle neuen Benutzer",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -256,8 +256,8 @@
     "EXECUTE": "Execute",
     "GET_DATA": "Retrieve data",
     "APPLY_CONFIGURATION": "Apply configuration",
-    "CUSTOMIZE_CONFIGURATION": "Customize configuration",
-    "RESET_CUSTOMIZATION": "Reset configuration",
+    "CUSTOMIZE_CONFIGURATION": "Filter data",
+    "RESET_CUSTOMIZATION": "Reset filter",
     "CREATE_ORGANIZATION": "Create organization",
     "UPDATE_NAME": "Update name",
     "DETERMINE": "Determine",
@@ -388,7 +388,7 @@
     "EXPLORE_PROJECT": "Retrieve project data",
     "EXPLORE_PROJECT_CONTENT": "On this page you have the possibility to retrieve the research data defined within the project.\n\nYou can either start the data retrieval directly or optionally restrict the data retrieval defined in the project even further.",
     "RESULT_SET": "Result Set",
-    "NO_RESULTS_YET": "No results yet. Please press the button 'Get Data' first.",
+    "NO_RESULTS_YET": "No results yet. Please press the button 'Retreive Data' first.",
     "LOADING_RESULT_SET": "The result set is being loaded. Please wait a moment.",
     "EMPTY_RESULT_SET": "The configuration did not give any results. Please change the configuration and try again.",
     "CONFIGURATION": "Configuration",
@@ -399,7 +399,9 @@
     "QUERY_BUILDER_DIALOG_HEADER": "Edit data criterium configuration",
     "RESULT_SET_ERROR": "The results could not be loaded. Please adjust the configuration and try again.",
     "EXPORT": "Export {{format}}",
-    "EXPORT_ERROR": "Error while trying to Export the {{format}} file, please try again later."
+    "EXPORT_ERROR": "Error while trying to Export the {{format}} file, please try again later.",
+    "HEADLINE_RETREIVE_SECTION": "Retreive data",
+    "INTRODUCTION_RETREIVE_SECTION": "Retreive data, restrict the result set with filters or reset previously defined filter. Caution: Using custom filters might reult in unexpected cross products."
   },
   "USER_MANAGEMENT": {
     "NEW_USERS_HEADER": "All New Users",


### PR DESCRIPTION
## Changes

This PR changes the button labels in Data Explorer to customize the result to a filter wording and adds an introduction text thats contains a warning about possible cross products due to the filter usage.

Additional the english version of the hint to hit the button first has been changed to use the wording "Retrieve data" instead of "Get data".

## Related issues

Task: [NUM-1792: Rename data explorer configuration](https://jira.vitagroup.ag/browse/NUM-1792)