### PR TITLE
NUM-1797 NUM logo is not shown on Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog][keep a changelog] and this project adh
 
 - Project editor: Hide edit button from approvers ([#291])
 - Dashboard: Fixes layout issues for safari on mac os catalina ([#292])
+- Dashboard: Logo not displayed in Firefor ([#303])
 - Footer: Fixes layout on smaller devices ([#293])
 
 ---
@@ -576,3 +577,4 @@ The format is based on [Keep a Changelog][keep a changelog] and this project adh
 [#291]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/291
 [#292]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/292
 [#293]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/293
+[#303]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/303

--- a/src/app/modules/dashboard/components/dashboard/dashboard.component.html
+++ b/src/app/modules/dashboard/components/dashboard/dashboard.component.html
@@ -36,7 +36,7 @@
         {{ 'DASHBOARD.INTRODUCTION.INITIATIVE' | translate }}
       </div>
       <div fxLayout="row wrap" class="num-margin-b-10">
-        <div fxFlex.sm="33%" *ngFor="let logo of initiativeLogos">
+        <div fxFlex.sm="33%" fxFlex="100%" *ngFor="let logo of initiativeLogos">
           <img
             [attr.src]="participantLogosBaseUrl + logo"
             class="initiative-logo"


### PR DESCRIPTION
## Changes

This PR fixes the issue that the logo on the Dashboard is not visible in Firefox.

## Related issue

Defect: [NUM-1797: NUM logo is not shown on Firefox](https://jira.vitagroup.ag/browse/NUM-1797)