### PR TITLE
NUM-1801 Unclear "usage"-field in criteria definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog][keep a changelog] and this project adh
 - Data Explorer: Change english hint to use button to retreive data first ([#302])
 - Dashboard: Add table headers to latest project table ([#305])
 - Cohort-Builder: Full set of logical operators just for numeric types ([#306])
+- Criteria Table: Label of private / public column ([#307])
 
 ### Fixed
 
@@ -597,3 +598,4 @@ The format is based on [Keep a Changelog][keep a changelog] and this project adh
 [#304]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/304
 [#305]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/305
 [#306]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/306
+[#307]: https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/pull/307

--- a/src/app/modules/aqls/components/aql-table/aql-table.component.html
+++ b/src/app/modules/aqls/components/aql-table/aql-table.component.html
@@ -124,7 +124,14 @@
           {{ 'FORM.USAGE' | translate }}
         </th>
         <td mat-cell *matCellDef="let element" data-test="aqls__table__data__is-public">
-          <fa-icon [icon]="element.publicAql ? ['far', 'eye'] : 'user-lock'"></fa-icon>
+          <fa-icon
+            [icon]="element.publicAql ? ['far', 'eye'] : 'user-lock'"
+            [matTooltip]="
+              element.publicAql
+                ? ('QUERIES.PRIVACY_PUBLIC' | translate)
+                : ('QUERIES.PRIVACY_PRIVATE' | translate)
+            "
+          ></fa-icon>
         </td>
       </ng-container>
 

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -108,7 +108,9 @@
       "MESSAGE_SET_ALL_PARAMETERS": "Sie sollten zuerst das Kriterium definieren, um ein valides Ergebnis zu erhalten.",
       "MESSAGE_ERROR_FEW_HITS": "Übereinstimmende Treffer liegen unter der Mindestschwelle.",
       "MESSAGE_ERROR_MESSAGE": "Konnte keine Treffer ermitteln. Bitte versuchen Sie es erneut."
-    }
+    },
+    "PRIVACY_PRIVATE": "Nur mit mir",
+    "PRIVACY_PUBLIC": "Öffentlich"
   },
   "CONTENT_EDITOR": {
     "SAVE_NAVIGATION_SUCCESS": "Die Navigationselemente wurden erfolgreich veröffentlicht.",
@@ -202,7 +204,7 @@
     "FILTER": "Filter",
     "ACTION": "Aktion",
     "CREATION_DATE": "Erstellungsdatum",
-    "USAGE": "Nutzung",
+    "USAGE": "Geteilt",
     "YES": "Ja",
     "NO": "Nein",
     "VALUE": "Wert",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -108,7 +108,9 @@
       "MESSAGE_SET_ALL_PARAMETERS": "You should first define the criterium to get a valid result.",
       "MESSAGE_ERROR_FEW_HITS": "Matching Hits are below minimum threshold.",
       "MESSAGE_ERROR_MESSAGE": "Could not determine Hits. Please try again."
-    }
+    },
+    "PRIVACY_PRIVATE": "Only with me",
+    "PRIVACY_PUBLIC": "Public"
   },
   "CONTENT_EDITOR": {
     "SAVE_NAVIGATION_SUCCESS": "The navigations items were successfully published.",
@@ -201,7 +203,7 @@
     "FILTER": "Filter",
     "ACTION": "Action",
     "CREATION_DATE": "Creation Date",
-    "USAGE": "Usage",
+    "USAGE": "Shared",
     "YES": "Yes",
     "NO": "No",
     "VALUE": "Value",


### PR DESCRIPTION
## Changes

This PR changes the table header of column "usage" of the criteria table and adds a tooltip to each cell icon for the privacy explaining the audience that is able to use the criteria query.

- Change table header for usage
- Add tooltip for private public usage