### PR TITLE
NUM-1845 Collapse icons wrong in Firefox (Data Retrieval)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "dependencies": {
         "@angular/animations": "~11.2.14",
         "@angular/cdk": "^11.2.13",

--- a/src/app/modules/data-explorer/components/data-explorer/data-explorer.component.scss
+++ b/src/app/modules/data-explorer/components/data-explorer/data-explorer.component.scss
@@ -16,7 +16,6 @@
 :host {
   width: 100%;
   margin: 0 0 60px 0;
-  white-space: pre-wrap;
 }
 
 mat-divider {


### PR DESCRIPTION
## Changes

This PR fixes the collapse indicators on data retrieval page were displayed wrong on Firefox due to a legacy white-space handling in that page. 

