### PR TITLE
feat(NUM-1886): Adds filter and search to cohort builder

### DIFF
--- a/src/app/core/services/aql/test/aql-filter-testcases.ts
+++ b/src/app/core/services/aql/test/aql-filter-testcases.ts
@@ -66,3 +66,41 @@ export const aqlFilterTestcases: { filter: IAqlFilter; resultLength: number }[] 
     resultLength: 0,
   },
 ]
+export const aqlFilterLanguageTestcases: {
+  filter: IAqlFilter
+  resultLength: number
+  lang: string
+}[] = [
+  {
+    filter: {
+      filterItem: [],
+      searchText: 'germanName1',
+    },
+    lang: 'de',
+    resultLength: 1,
+  },
+  {
+    filter: {
+      filterItem: [],
+      searchText: 'germanName1',
+    },
+    lang: 'en',
+    resultLength: 0,
+  },
+  {
+    filter: {
+      filterItem: [],
+      searchText: 'englishName2',
+    },
+    lang: 'de',
+    resultLength: 0,
+  },
+  {
+    filter: {
+      filterItem: [],
+      searchText: 'englishName2',
+    },
+    lang: 'en',
+    resultLength: 1,
+  },
+]

--- a/src/app/core/services/aql/test/aql.service.spec.ts
+++ b/src/app/core/services/aql/test/aql.service.spec.ts
@@ -18,14 +18,21 @@ import { HttpClient } from '@angular/common/http'
 import { of, Subject, throwError, timer } from 'rxjs'
 import { AppConfigService } from 'src/app/config/app-config.service'
 import { IAqlFilter } from 'src/app/shared/models/aql/aql-filter.interface'
-import { mockAql1, mockAqls, mockAqlsToFilter } from 'src/mocks/data-mocks/aqls.mock'
+import {
+  mockAql1,
+  mockAqls,
+  mockAqlsToFilter,
+  mockAqlsToFilterWithLanguage,
+} from 'src/mocks/data-mocks/aqls.mock'
 import { AqlService } from '../aql.service'
 import { AqlEditorUiModel } from 'src/app/shared/models/aql/aql-editor-ui.model'
 import { ProfileService } from '../../profile/profile.service'
 import { skipUntil } from 'rxjs/operators'
 import { IAqlApi } from 'src/app/shared/models/aql/aql.interface'
-import { aqlFilterTestcases } from './aql-filter-testcases'
+import { aqlFilterLanguageTestcases, aqlFilterTestcases } from './aql-filter-testcases'
 import { mockUserProfile1 } from 'src/mocks/data-mocks/user-profile.mock'
+import { LangChangeEvent, TranslateService } from '@ngx-translate/core'
+import { EventEmitter } from '@angular/core'
 
 describe('AqlService', () => {
   let service: AqlService
@@ -52,6 +59,12 @@ describe('AqlService', () => {
     userProfileObservable$: userProfileSubject$.asObservable(),
   } as unknown as ProfileService
 
+  let onLanguageChangeSubject$: EventEmitter<any>
+  const mockTranslateService = {
+    onLangChange: jest.fn(),
+    currentLang: 'de',
+  } as unknown as TranslateService
+
   const filterConfig: IAqlFilter = {
     filterItem: [],
     searchText: 'test',
@@ -59,9 +72,10 @@ describe('AqlService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-
+    const mockTranslateServiceAny = mockTranslateService as any
+    mockTranslateServiceAny.onLangChange = new EventEmitter<any>()
     jest.spyOn(httpClient, 'get').mockImplementation(() => of())
-    service = new AqlService(httpClient, appConfig, userProfileService)
+    service = new AqlService(httpClient, appConfig, userProfileService, mockTranslateService)
   })
 
   it('should be created', () => {
@@ -221,6 +235,44 @@ describe('AqlService', () => {
 
       const result = service.filterItems(mockAqlsToFilter as IAqlApi[], testcase.filter)
       expect(result.length).toEqual(testcase.resultLength)
+    })
+  })
+
+  describe('When passing in filters', () => {
+    test.each(aqlFilterTestcases)('It should filter as expected', (testcase) => {
+      const anyService = service as any
+      anyService.user = { id: '1', organization: { id: 1 } }
+
+      const result = service.filterItems(mockAqlsToFilter as IAqlApi[], testcase.filter)
+      expect(result.length).toEqual(testcase.resultLength)
+    })
+  })
+
+  describe('When changing the language', () => {
+    let serviceAny: any
+    beforeEach(() => {
+      serviceAny = service as any
+      serviceAny.aqls = mockAqlsToFilterWithLanguage
+    })
+
+    test.each(aqlFilterLanguageTestcases)('It should filter as expected', (testcase, done: any) => {
+      serviceAny.filterSet = testcase.filter
+      let callCounter = 0
+      service.filteredAqlsObservable$.subscribe((aqls) => {
+        // Filter out the initial filter on service start
+        if (callCounter === 0) {
+          callCounter++
+          mockTranslateService.onLangChange.next({ lang: testcase.lang } as LangChangeEvent)
+        } else {
+          if (
+            testcase.lang === service.currentLang &&
+            serviceAny.filterSet.searchText === testcase.filter.searchText
+          ) {
+            expect(aqls.length).toEqual(testcase.resultLength)
+            done()
+          }
+        }
+      })
     })
   })
 

--- a/src/app/modules/aqls/components/aql-table/aql-table.component.html
+++ b/src/app/modules/aqls/components/aql-table/aql-table.component.html
@@ -97,7 +97,8 @@
           {{ 'FORM.AUTHOR' | translate }}
         </th>
         <td mat-cell *matCellDef="let element" data-test="aqls__table__data__author">
-          {{ element.owner.firstName }} {{ element.owner.lastName }}
+          {{ element.owner ? element.owner?.firstName : ('USER.UNKNOWN' | translate) }}
+          {{ element.owner ? element.owner?.lastName : '' }}
         </td>
       </ng-container>
 
@@ -106,7 +107,7 @@
           {{ 'USER.ORGANIZATION' | translate }}
         </th>
         <td mat-cell *matCellDef="let element" data-test="aqls__table__data__organization">
-          {{ element.owner.organization?.name }}
+          {{ element.owner?.organization?.name }}
         </td>
       </ng-container>
 

--- a/src/app/modules/cohort-builder/components/aql-selection/aql-selection.component.html
+++ b/src/app/modules/cohort-builder/components/aql-selection/aql-selection.component.html
@@ -15,17 +15,18 @@
 -->
 
 <mat-accordion class="num-accordion num-accordion-small">
-  <mat-expansion-panel *ngFor="let aqlGroup of groupedAqls | async | keyvalue">
+  <p class="no-results" *ngIf="noResults">
+    <fa-icon [fixedWidth]="true" class="num-fc--w" icon="exclamation-circle"></fa-icon>
+    {{ 'NO_FILTER_RESULTS' | translate }}
+  </p>
+  <mat-expansion-panel *ngFor="let aqlGroup of groupedAqls | async">
     <mat-expansion-panel-header
-      *ngIf="aqlCategories[aqlGroup.key]"
-      [attr.data-test]="'cohort-builder__aql-selection__category--' + aqlGroup.key"
-      >{{
-        aqlCategories[aqlGroup.key] ? aqlCategories[aqlGroup.key][currentLang] : ''
-      }}</mat-expansion-panel-header
+      [attr.data-test]="'cohort-builder__aql-selection__category--' + aqlGroup.categoryId"
+      >{{ aqlGroup[currentLang] }}</mat-expansion-panel-header
     >
     <div
       class="aql"
-      *ngFor="let aql of aqlGroup.value"
+      *ngFor="let aql of aqlGroup.aqls"
       fxLayout="row"
       fxLayoutAlign="space-between center"
     >

--- a/src/app/modules/cohort-builder/components/aql-selection/aql-selection.component.scss
+++ b/src/app/modules/cohort-builder/components/aql-selection/aql-selection.component.scss
@@ -30,3 +30,7 @@
     }
   }
 }
+
+.no-results {
+  padding: 16px 16px 8px 16px;
+}

--- a/src/app/modules/cohort-builder/components/aql-selection/aql-selection.component.spec.ts
+++ b/src/app/modules/cohort-builder/components/aql-selection/aql-selection.component.spec.ts
@@ -26,7 +26,13 @@ import { AqlUiModel } from 'src/app/shared/models/aql/aql-ui.model'
 import { IAqlApi } from 'src/app/shared/models/aql/aql.interface'
 import { IAqlCategoryApi } from 'src/app/shared/models/aql/category/aql-category.interface'
 import { mockAqlCategories } from 'src/mocks/data-mocks/aql-categories.mock'
-import { mockAql1, mockAql4, mockAqls, mockAqlsToSort } from 'src/mocks/data-mocks/aqls.mock'
+import {
+  mockAql1,
+  mockAql12,
+  mockAql4,
+  mockAqls,
+  mockAqlsToSort,
+} from 'src/mocks/data-mocks/aqls.mock'
 import { AqlSelectionComponent } from './aql-selection.component'
 
 describe('AqlSelectionComponent', () => {
@@ -40,7 +46,7 @@ describe('AqlSelectionComponent', () => {
   const aqlsSubject = new Subject<IAqlApi[]>()
   const mockAqlService = {
     getAll: jest.fn(),
-    aqlsObservable$: aqlsSubject.asObservable(),
+    filteredAqlsObservable$: aqlsSubject.asObservable(),
   } as unknown as AqlService
 
   const aqlsCategoriesSubject = new Subject<IAqlCategoryApi[]>()
@@ -76,35 +82,21 @@ describe('AqlSelectionComponent', () => {
   })
 
   describe('On init', () => {
-    it('should set the default category', (done) => {
-      mockAqlCategoryService.aqlCategoriesObservable$.subscribe(() => {
-        expect(component.aqlCategories).toEqual(component.initialCategories)
-        done()
-      })
+    it('should set the default category', () => {
       expect(component.initialCategories).toBeTruthy()
-      aqlsCategoriesSubject.next([])
-    })
-
-    it('should subscribe to receive and restructure the categories', (done) => {
-      mockAqlCategoryService.aqlCategoriesObservable$.subscribe(() => {
-        expect(component.aqlCategories[mockAqlCategories[0].id]).toEqual(mockAqlCategories[0].name)
-        expect(component.aqlCategories[mockAqlCategories[1].id]).toEqual(mockAqlCategories[1].name)
-        expect(component.aqlCategories[mockAqlCategories[2].id]).toEqual(mockAqlCategories[2].name)
-        done()
-      })
-      aqlsCategoriesSubject.next(mockAqlCategories)
     })
 
     it('should subscribe to receive and group the aqls by category', (done) => {
-      component.groupedAqls.subscribe((aqls) => {
-        expect(aqls[0].length).toBeTruthy()
-        expect(aqls[1].length).toBeTruthy()
-        expect(aqls[2].length).toBeTruthy()
-        expect(aqls[3].length).toBeTruthy()
-        expect(aqls[0][0].id).toEqual(mockAql4.id)
+      component.groupedAqls.subscribe((groups) => {
+        expect(groups[0].aqls.length).toBeTruthy()
+        expect(groups[1].aqls.length).toBeTruthy()
+        expect(groups[2].aqls.length).toBeTruthy()
+        expect(groups[3].aqls.length).toBeTruthy()
+        expect(groups[0].aqls[0].id).toEqual(mockAql12.id)
         done()
       })
       aqlsSubject.next([mockAql4, ...mockAqlsToSort])
+      aqlsCategoriesSubject.next(mockAqlCategories)
     })
   })
 
@@ -114,6 +106,21 @@ describe('AqlSelectionComponent', () => {
       expect(mockCohortBuilderService.pushItemToTarget).toHaveBeenCalledWith(
         new AqlUiModel(mockAql1)
       )
+    })
+  })
+
+  describe('on language change', () => {
+    it('should set the current lang and group and sort the aqls', (done) => {
+      jest.spyOn(component, 'groupAndSortAql')
+      const componentAny = fixture.componentInstance as any
+
+      componentAny.translateService.onLangChange.subscribe(() => {
+        expect(component.currentLang).toEqual('de')
+        expect(component.groupAndSortAql).toHaveBeenCalledTimes(1)
+        done()
+      })
+
+      componentAny.translateService.use('de')
     })
   })
 })

--- a/src/app/modules/cohort-builder/components/aql-selection/aql-selection.component.ts
+++ b/src/app/modules/cohort-builder/components/aql-selection/aql-selection.component.ts
@@ -105,11 +105,9 @@ export class AqlSelectionComponent implements OnInit, OnDestroy {
       tap(([aqls]) => (this.noResults = aqls.length <= 0)),
       map(([aqls, categories]) => {
         const nameField = this.currentLang === 'de' ? 'name' : 'nameTranslated'
-        const sortedAql = aqls.sort((a, b) =>
-          compareLocaleStringValues(a[nameField], b[nameField], a.id, b.id, true)
-        )
+        aqls.sort((a, b) => compareLocaleStringValues(a[nameField], b[nameField], a.id, b.id, true))
         const aqlCategories = this.reduceCategories(categories)
-        return Object.entries(groupBy(sortedAql, (item) => item.categoryId || 0))
+        return Object.entries(groupBy(aqls, (item) => item.categoryId || 0))
           .sort(([keyA, _valueA], [keyB, _valueB]) => {
             // If no category is specified or the category is no longer existend we default to 0
             const categoryKeyA = aqlCategories[+keyA] ? +keyA : 0

--- a/src/app/modules/cohort-builder/components/aql-selection/aql-selection.component.ts
+++ b/src/app/modules/cohort-builder/components/aql-selection/aql-selection.component.ts
@@ -17,14 +17,16 @@
 import { Component, OnDestroy, OnInit } from '@angular/core'
 import { TranslateService } from '@ngx-translate/core'
 import { groupBy } from 'lodash-es'
-import { Observable, Subscription } from 'rxjs'
-import { map } from 'rxjs/operators'
+import { combineLatest, Observable, Subscription } from 'rxjs'
+import { map, tap } from 'rxjs/operators'
 import { AqlCategoryService } from 'src/app/core/services/aql-category/aql-category.service'
 import { AqlService } from 'src/app/core/services/aql/aql.service'
 import { CohortBuilderService } from 'src/app/core/services/cohort-builder/cohort-builder.service'
 import { DialogService } from 'src/app/core/services/dialog/dialog.service'
+import { compareLocaleStringValues } from 'src/app/core/utils/sort.utils'
 import { AqlUiModel } from 'src/app/shared/models/aql/aql-ui.model'
 import { IAqlApi } from 'src/app/shared/models/aql/aql.interface'
+import { IAqlCategoryApi } from 'src/app/shared/models/aql/category/aql-category.interface'
 import { DialogConfig } from 'src/app/shared/models/dialog/dialog-config.interface'
 import { IDictionary } from 'src/app/shared/models/dictionary.interface'
 import { INFO_DIALOG_CONFIG } from './constants'
@@ -45,9 +47,17 @@ export class AqlSelectionComponent implements OnInit, OnDestroy {
   ) {}
 
   currentLang = this.translateService.currentLang || 'en'
-  groupedAqls: Observable<IDictionary<number, IAqlApi[]>>
-  aqlCategories: IDictionary<number, IDictionary<string, string>>
+  groupedAqls: Observable<
+    {
+      de: string
+      en: string
+      categoryId: number
+      aqls: IAqlApi[]
+    }[]
+  >
+
   initialCategories: IDictionary<number, IDictionary<string, string>>
+  noResults = false
 
   ngOnInit(): void {
     this.initialCategories = {
@@ -60,33 +70,70 @@ export class AqlSelectionComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.translateService.onLangChange.subscribe((event) => {
         this.currentLang = event.lang || 'en'
-        this.aqlCategories[0][event.lang] = this.translateService.instant(
+        this.initialCategories[0][event.lang] = this.translateService.instant(
           'QUERY_CATEGORIES.UNCATEGORIZED'
         )
+        this.groupAndSortAql()
       })
     )
     this.subscriptions.add(this.aqlCategoryService.getAll().subscribe())
-    this.subscriptions.add(
-      this.aqlCategoryService.aqlCategoriesObservable$.subscribe((aqlCategories) => {
-        this.aqlCategories = aqlCategories.reduce((acc, category) => {
-          acc[category.id] = {
-            de: category.name.de,
-            en: category.name.en,
-          }
-          return acc
-        }, this.initialCategories)
-      })
-    )
     this.subscriptions.add(this.aqlService.getAll().subscribe())
-    this.groupedAqls = this.aqlService.aqlsObservable$.pipe(
-      map((aqls) => {
-        return groupBy(aqls, (item) => item.categoryId || 0)
-      })
-    )
+    this.groupAndSortAql()
   }
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe()
+  }
+
+  reduceCategories(
+    aqlCategories: IAqlCategoryApi[]
+  ): IDictionary<number, IDictionary<string, string>> {
+    return aqlCategories.reduce((acc, category) => {
+      acc[category.id] = {
+        de: category.name.de,
+        en: category.name.en,
+      }
+      return acc
+    }, this.initialCategories)
+  }
+
+  groupAndSortAql(): void {
+    this.groupedAqls = combineLatest([
+      this.aqlService.filteredAqlsObservable$,
+      this.aqlCategoryService.aqlCategoriesObservable$,
+    ]).pipe(
+      tap(([aqls]) => (this.noResults = aqls.length <= 0)),
+      map(([aqls, categories]) => {
+        const nameField = this.currentLang === 'de' ? 'name' : 'nameTranslated'
+        const sortedAql = aqls.sort((a, b) =>
+          compareLocaleStringValues(a[nameField], b[nameField], a.id, b.id, true)
+        )
+        const aqlCategories = this.reduceCategories(categories)
+        return Object.entries(groupBy(sortedAql, (item) => item.categoryId || 0))
+          .sort(([keyA, _valueA], [keyB, _valueB]) => {
+            // If no category is specified or the category is no longer existend we default to 0
+            const categoryKeyA = aqlCategories[+keyA] ? +keyA : 0
+            const categoryKeyB = aqlCategories[+keyB] ? +keyB : 0
+            return compareLocaleStringValues(
+              aqlCategories[categoryKeyA][this.currentLang],
+              aqlCategories[categoryKeyB][this.currentLang],
+              categoryKeyA,
+              categoryKeyB,
+              true
+            )
+          })
+          .map(([key, value]) => {
+            // If no category is specified or the category is no longer existend we default to 0
+            const categoryKey = aqlCategories[+key] ? +key : 0
+            return {
+              de: aqlCategories[categoryKey].de,
+              en: aqlCategories[categoryKey].en,
+              categoryId: categoryKey,
+              aqls: value,
+            }
+          })
+      })
+    )
   }
 
   emitAqlEvent(aqlApi: IAqlApi): void {

--- a/src/app/modules/cohort-builder/components/cohort-builder/cohort-builder.component.scss
+++ b/src/app/modules/cohort-builder/components/cohort-builder/cohort-builder.component.scss
@@ -16,6 +16,7 @@
 
 :host,
 .cohort-builder {
+  display: block;
   width: 100%;
 }
 

--- a/src/app/modules/projects/components/project-editor-cohort-builder/project-editor-cohort-builder.component.html
+++ b/src/app/modules/projects/components/project-editor-cohort-builder/project-editor-cohort-builder.component.html
@@ -27,12 +27,21 @@
     </mat-panel-title>
   </mat-expansion-panel-header>
 
-  <num-editor-determine-hits
-    *ngIf="!isDisabled"
-    class="num-margin-b-20"
-    [content]="determineHitsContent"
-    (clicked)="determineHitsClicked.emit()"
-  ></num-editor-determine-hits>
+  <section fxLayout="row">
+    <num-filter-chips
+      [filterChips]="filterConfig.filterItem"
+      [multiSelect]="false"
+      (selectionChange)="handleFilterChange()"
+    ></num-filter-chips>
+
+    <num-search
+      fxFlexOffset="auto"
+      fxFlex="25%"
+      label="QUERIES.SEARCH_QUERIES"
+      [(searchText)]="filterConfig.searchText"
+      (searchTextChange)="handleSearchChange()"
+    ></num-search>
+  </section>
 
   <num-cohort-builder
     [cohortNode]="cohortNode"
@@ -40,5 +49,14 @@
     [raised]="false"
     [isDisabled]="isDisabled"
     data-test="project-editor__cohort-builder"
+    class="num-margin-b-20"
   ></num-cohort-builder>
+
+  <mat-divider class="num-d-c--g num-d-w--1 num-margin-b-20"></mat-divider>
+
+  <num-editor-determine-hits
+    *ngIf="!isDisabled"
+    [content]="determineHitsContent"
+    (clicked)="determineHitsClicked.emit()"
+  ></num-editor-determine-hits>
 </mat-expansion-panel>

--- a/src/app/modules/projects/components/project-editor-cohort-builder/project-editor-cohort-builder.component.html
+++ b/src/app/modules/projects/components/project-editor-cohort-builder/project-editor-cohort-builder.component.html
@@ -27,7 +27,7 @@
     </mat-panel-title>
   </mat-expansion-panel-header>
 
-  <section fxLayout="row">
+  <section fxLayout="row" *ngIf="!isDisabled">
     <num-filter-chips
       [filterChips]="filterConfig.filterItem"
       [multiSelect]="false"

--- a/src/app/modules/projects/components/project-editor-cohort-builder/project-editor-cohort-builder.component.spec.ts
+++ b/src/app/modules/projects/components/project-editor-cohort-builder/project-editor-cohort-builder.component.spec.ts
@@ -16,10 +16,17 @@
 
 import { Component, EventEmitter, Input, Output } from '@angular/core'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ReactiveFormsModule } from '@angular/forms'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing'
 import { TranslateModule } from '@ngx-translate/core'
+import { BehaviorSubject, Subject } from 'rxjs'
+import { AqlService } from 'src/app/core/services/aql/aql.service'
 import { MaterialModule } from 'src/app/layout/material/material.module'
+import { SearchComponent } from 'src/app/shared/components/search/search.component'
+import { IAqlFilter } from 'src/app/shared/models/aql/aql-filter.interface'
+import { IAqlApi } from 'src/app/shared/models/aql/aql.interface'
+import { IFilterItem } from 'src/app/shared/models/filter-chip.interface'
 import { CohortGroupUiModel } from 'src/app/shared/models/project/cohort-group-ui.model'
 
 import { ProjectEditorCohortBuilderComponent } from './project-editor-cohort-builder.component'
@@ -27,6 +34,15 @@ import { ProjectEditorCohortBuilderComponent } from './project-editor-cohort-bui
 describe('ProjectEditorCohortBuilderComponent', () => {
   let component: ProjectEditorCohortBuilderComponent
   let fixture: ComponentFixture<ProjectEditorCohortBuilderComponent>
+
+  const filteredAqlsSubject$ = new Subject<IAqlApi[]>()
+  const filterConfigSubject$ = new BehaviorSubject<IAqlFilter>({ searchText: '', filterItem: [] })
+
+  const mockAqlService = {
+    setFilter: jest.fn(),
+    filteredAqlsObservable$: filteredAqlsSubject$.asObservable(),
+    filterConfigObservable$: filterConfigSubject$.asObservable(),
+  } as unknown as AqlService
 
   @Component({ selector: 'num-cohort-builder', template: '' })
   class StubCohortBuilderComponent {
@@ -43,23 +59,40 @@ describe('ProjectEditorCohortBuilderComponent', () => {
     @Output() clicked = new EventEmitter()
   }
 
+  @Component({ selector: 'num-filter-chips', template: '' })
+  class StubFilterChipsComponent {
+    @Input() filterChips: IFilterItem<string | number>[]
+    @Input() multiSelect: boolean
+    @Output() selectionChange = new EventEmitter()
+  }
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [
         ProjectEditorCohortBuilderComponent,
         StubCohortBuilderComponent,
         StubEditorDetermineHitsComponent,
+        SearchComponent,
+        StubFilterChipsComponent,
       ],
       imports: [
         MaterialModule,
+        ReactiveFormsModule,
         TranslateModule.forRoot(),
         FontAwesomeTestingModule,
         BrowserAnimationsModule,
+      ],
+      providers: [
+        {
+          provide: AqlService,
+          useValue: mockAqlService,
+        },
       ],
     }).compileComponents()
   })
 
   beforeEach(() => {
+    jest.spyOn(mockAqlService, 'setFilter')
     fixture = TestBed.createComponent(ProjectEditorCohortBuilderComponent)
     component = fixture.componentInstance
 
@@ -69,5 +102,17 @@ describe('ProjectEditorCohortBuilderComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  describe('When the user wants to filter and search aqls', () => {
+    it('should set the filter in the aqlService on searchChange', () => {
+      component.handleSearchChange()
+      expect(mockAqlService.setFilter).toHaveBeenCalledWith(component.filterConfig)
+    })
+
+    it('should set the filter in the aqlService on filterChange', () => {
+      component.handleFilterChange()
+      expect(mockAqlService.setFilter).toHaveBeenCalledWith(component.filterConfig)
+    })
   })
 })

--- a/src/app/modules/projects/components/project-editor-cohort-builder/project-editor-cohort-builder.component.ts
+++ b/src/app/modules/projects/components/project-editor-cohort-builder/project-editor-cohort-builder.component.ts
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
-import { Component, EventEmitter, Input, Output } from '@angular/core'
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core'
+import { Subscription } from 'rxjs'
+import { take } from 'rxjs/operators'
+import { AqlService } from 'src/app/core/services/aql/aql.service'
 import { IDetermineHits } from 'src/app/shared/components/editor-determine-hits/determine-hits.interface'
+import { IAqlFilter } from 'src/app/shared/models/aql/aql-filter.interface'
 import { CohortGroupUiModel } from 'src/app/shared/models/project/cohort-group-ui.model'
 
 @Component({
@@ -23,7 +27,9 @@ import { CohortGroupUiModel } from 'src/app/shared/models/project/cohort-group-u
   templateUrl: './project-editor-cohort-builder.component.html',
   styleUrls: ['./project-editor-cohort-builder.component.scss'],
 })
-export class ProjectEditorCohortBuilderComponent {
+export class ProjectEditorCohortBuilderComponent implements OnInit {
+  private subscriptions = new Subscription()
+
   @Input() cohortNode: CohortGroupUiModel
   @Input() isLoadingComplete: boolean
   @Input() isDisabled: boolean
@@ -31,5 +37,23 @@ export class ProjectEditorCohortBuilderComponent {
   @Input() determineHitsContent: IDetermineHits
   @Output() determineHitsClicked = new EventEmitter()
 
-  constructor() {}
+  filterConfig: IAqlFilter
+
+  constructor(private aqlService: AqlService) {}
+
+  ngOnInit(): void {
+    this.subscriptions.add(
+      this.aqlService.filterConfigObservable$
+        .pipe(take(1))
+        .subscribe((config) => (this.filterConfig = config))
+    )
+  }
+
+  handleFilterChange(): void {
+    this.aqlService.setFilter(this.filterConfig)
+  }
+
+  handleSearchChange(): void {
+    this.aqlService.setFilter(this.filterConfig)
+  }
 }

--- a/src/app/modules/search/components/patient-filter/patient-filter.component.html
+++ b/src/app/modules/search/components/patient-filter/patient-filter.component.html
@@ -20,6 +20,22 @@
 
 <num-patient-count-info [patientCount]="patientCount$ | async"></num-patient-count-info>
 
+<section fxLayout="row">
+  <num-filter-chips
+    [filterChips]="filterConfig.filterItem"
+    [multiSelect]="false"
+    (selectionChange)="handleFilterChange()"
+  ></num-filter-chips>
+
+  <num-search
+    fxFlexOffset="auto"
+    fxFlex="25%"
+    label="QUERIES.SEARCH_QUERIES"
+    [(searchText)]="filterConfig.searchText"
+    (searchTextChange)="handleSearchChange()"
+  ></num-search>
+</section>
+
 <num-cohort-builder
   [cohortNode]="cohortNode"
   [raised]="true"

--- a/src/app/modules/search/components/patient-filter/patient-filter.component.ts
+++ b/src/app/modules/search/components/patient-filter/patient-filter.component.ts
@@ -17,11 +17,13 @@ import { Component, OnDestroy, OnInit } from '@angular/core'
 import { Router } from '@angular/router'
 import { Observable, Subscription } from 'rxjs'
 import { filter, map, take } from 'rxjs/operators'
+import { AqlService } from 'src/app/core/services/aql/aql.service'
 import { CohortService } from 'src/app/core/services/cohort/cohort.service'
 import { PatientFilterService } from 'src/app/core/services/patient-filter/patient-filter.service'
 import { ProfileService } from 'src/app/core/services/profile/profile.service'
 import { ToastMessageService } from 'src/app/core/services/toast-message/toast-message.service'
 import { IDetermineHits } from 'src/app/shared/components/editor-determine-hits/determine-hits.interface'
+import { IAqlFilter } from 'src/app/shared/models/aql/aql-filter.interface'
 import { AvailableRoles } from 'src/app/shared/models/available-roles.enum'
 import { ICohortPreviewApi } from 'src/app/shared/models/cohort-preview.interface'
 import { ICohortGroupApi } from 'src/app/shared/models/project/cohort-group-api.interface'
@@ -46,6 +48,8 @@ export class PatientFilterComponent implements OnInit, OnDestroy {
   previewData$: Observable<ICohortPreviewApi>
   project: ProjectUiModel
 
+  filterConfig: IAqlFilter
+
   get cohortNode(): CohortGroupUiModel {
     return this.project.cohortGroup
   }
@@ -55,7 +59,8 @@ export class PatientFilterComponent implements OnInit, OnDestroy {
     private router: Router,
     private toastMessageService: ToastMessageService,
     private cohortService: CohortService,
-    private profileService: ProfileService
+    private profileService: ProfileService,
+    private aqlService: AqlService
   ) {}
 
   ngOnInit(): void {
@@ -75,11 +80,25 @@ export class PatientFilterComponent implements OnInit, OnDestroy {
         .subscribe()
     )
 
+    this.subscriptions.add(
+      this.aqlService.filterConfigObservable$
+        .pipe(take(1))
+        .subscribe((config) => (this.filterConfig = config))
+    )
+
     this.patientFilterService.getAllDatasetCount().subscribe()
   }
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe()
+  }
+
+  handleFilterChange(): void {
+    this.aqlService.setFilter(this.filterConfig)
+  }
+
+  handleSearchChange(): void {
+    this.aqlService.setFilter(this.filterConfig)
   }
 
   setCurrentProject(): void {

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -156,6 +156,7 @@
       "NOTIFICATION": "Benachrichtigung"
     }
   },
+  "NO_FILTER_RESULTS": "Keine Ergebnisse. Bitte die Filter oder die Suche anpassen.",
   "TABLE": "Tabelle",
   "INVALID_URL": "Die URL ist nicht valide. Bitte an das Beispiel anpassen:",
   "PROVIDE_URL": "Bitte geben Sie eine URL ein",
@@ -365,7 +366,8 @@
     "ROLES": "Rollen",
     "NAME": "Name",
     "EMAIL": "E-Mail Adresse",
-    "REGISTER_DATE": "Registriert am"
+    "REGISTER_DATE": "Registriert am",
+    "UNKNOWN": "Unbekannter Nutzer"
   },
   "ROLE": {
     "RESEARCHER": "Forscher",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -155,6 +155,7 @@
       "NOTIFICATION": "Notification"
     }
   },
+  "NO_FILTER_RESULTS": "No results found. Please adjust the filter or search.",
   "TABLE": "Table",
   "INVALID_URL": "The URL is not valid. Please adjust to the example:",
   "PROVIDE_URL": "Please enter a URL",
@@ -364,7 +365,8 @@
     "ROLES": "Roles",
     "NAME": "Name",
     "EMAIL": "E-mail address",
-    "REGISTER_DATE": "Register date"
+    "REGISTER_DATE": "Register date",
+    "UNKNOWN": "Unknown User"
   },
   "ROLE": {
     "RESEARCHER": "Researcher",

--- a/src/mocks/data-mocks/aqls.mock.ts
+++ b/src/mocks/data-mocks/aqls.mock.ts
@@ -301,3 +301,32 @@ export const mockAqlsToFilter: DeepPartial<IAqlApi>[] = [
     },
   },
 ]
+
+export const mockAqlsToFilterWithLanguage: DeepPartial<IAqlApi>[] = [
+  {
+    id: 1,
+    name: 'germanName1',
+    nameTranslated: 'englishName1',
+    owner: {
+      id: '1',
+      firstName: '',
+      lastName: '',
+      organization: {
+        id: 1,
+      },
+    },
+  },
+  {
+    id: 2,
+    name: 'germanName2',
+    nameTranslated: 'englishName2',
+    owner: {
+      id: '1',
+      firstName: 'firstname2',
+      lastName: null,
+      organization: {
+        id: null,
+      },
+    },
+  },
+]

--- a/src/styles/custom-material/styles/_color-classes.themed.scss
+++ b/src/styles/custom-material/styles/_color-classes.themed.scss
@@ -32,7 +32,7 @@
     }
     &--warn,
     &--w {
-      color: mat-color($warn);
+      color: mat-color($warn, warning);
     }
     &--success,
     &--s {
@@ -60,7 +60,7 @@
     }
     &--disabled,
     &--d {
-      color: mat-color($additional, mid-grey);
+      background: mat-color($additional, mid-grey);
     }
   }
 }


### PR DESCRIPTION
**Story Description:**
Given I'm logged in as a Manager or Project Lead
When I build a cohort in Search
or I build a cohort in project editor

Then I can search for a criteria or category in a search box
and the search is language specific
and the list of criteria is filtered according to the entered characters
and the categories are ordered alphabetically according to the selected language
and the criteria inside the categories are ordered alphabetically according to the selected language
and categories with no matching criteria are hidden 
and I can reset the search box (clear), then no criteria is filtered out