### PR TITLE
feat(NUM-1930): Determine hits for manager

### DIFF
--- a/src/app/modules/search/components/cohort-graphs/cohort-graphs.component.html
+++ b/src/app/modules/search/components/cohort-graphs/cohort-graphs.component.html
@@ -27,6 +27,7 @@
   <mat-divider class="num-divider-color--grey num-divider-width--1 num-margin-b-20"></mat-divider>
 
   <ng-container *numUserHasRole="[availableRoles.Manager]">
+    <mat-spinner *ngIf="isChartDataLoading" color="accent" [diameter]="24"></mat-spinner>
     <div fxLayout="row" fxLayout.lt-lg="column" fxLayoutGap="32px" *ngIf="previewData.count > 0">
       <num-vertical-bar-chart
         color="#5F0D22"

--- a/src/app/modules/search/components/cohort-graphs/cohort-graphs.component.ts
+++ b/src/app/modules/search/components/cohort-graphs/cohort-graphs.component.ts
@@ -25,6 +25,7 @@ import { ICohortPreviewApi } from 'src/app/shared/models/cohort-preview.interfac
 })
 export class CohortGraphsComponent {
   @Input() determineHits: IDetermineHits
+  @Input() isChartDataLoading: boolean
   @Input() previewData: ICohortPreviewApi
   @Output() determine = new EventEmitter<void>()
 

--- a/src/app/modules/search/components/patient-filter/patient-filter.component.html
+++ b/src/app/modules/search/components/patient-filter/patient-filter.component.html
@@ -48,6 +48,7 @@
   class="num-margin-b-40"
   [previewData]="previewData$ | async"
   [determineHits]="determineHits"
+  [isChartDataLoading]="isChartDataLoading"
   (determine)="getPreviewData()"
 ></num-cohort-graphs>
 

--- a/src/app/modules/search/components/patient-filter/patient-filter.component.spec.ts
+++ b/src/app/modules/search/components/patient-filter/patient-filter.component.spec.ts
@@ -217,18 +217,24 @@ describe('PatientFilterComponent', () => {
       expect(component.determineHits.isLoading).toBe(false)
     })
 
-    it('gets the cohort size from patient filter service', async () => {
+    it('gets the cohort size from from cohort service', async () => {
       jest
         .spyOn(mockPatientFilterService, 'getPreviewData')
         .mockImplementation(() => of(mockCohortPreviewData))
+      jest.spyOn(mockCohortService, 'getSize').mockImplementation(() => of(528))
       await component.getPreviewData()
       expect(mockPatientFilterService.getPreviewData).toHaveBeenCalledTimes(1)
-      expect(component.determineHits.count).toEqual(mockCohortPreviewData.count)
+      expect(mockCohortService.getSize).toHaveBeenCalledTimes(1)
+      expect(component.determineHits.count).toEqual(528)
     })
 
     it('should show an error for to few hits', async () => {
       jest
         .spyOn(mockPatientFilterService, 'getPreviewData')
+        .mockImplementation(() => throwError(new HttpErrorResponse({ status: 451 })))
+
+      jest
+        .spyOn(mockCohortService, 'getSize')
         .mockImplementation(() => throwError(new HttpErrorResponse({ status: 451 })))
 
       await component.getPreviewData()
@@ -238,6 +244,10 @@ describe('PatientFilterComponent', () => {
     it('should show a general error message for unknown errors', async () => {
       jest
         .spyOn(mockPatientFilterService, 'getPreviewData')
+        .mockImplementation(() => throwError(new HttpErrorResponse({ status: 500 })))
+
+      jest
+        .spyOn(mockCohortService, 'getSize')
         .mockImplementation(() => throwError(new HttpErrorResponse({ status: 500 })))
       await component.getPreviewData()
       expect(component.determineHits.message).toEqual('PROJECT.HITS.MESSAGE_ERROR_MESSAGE')
@@ -261,18 +271,6 @@ describe('PatientFilterComponent', () => {
 
       await component.getPreviewData()
       expect(mockPatientFilterService.resetPreviewData).toHaveBeenCalledTimes(1)
-    })
-
-    it('should not call the getSize method from cohort service', async () => {
-      jest
-        .spyOn(mockPatientFilterService, 'getPreviewData')
-        .mockImplementation(() => of(mockCohortPreviewData))
-      jest.spyOn(mockCohortService, 'getSize')
-
-      await component.getPreviewData()
-
-      expect(mockPatientFilterService.getPreviewData).toHaveBeenCalled()
-      expect(mockCohortService.getSize).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
**Story-Description:**
Use the same endpoint to get the amount of hits also as Manager (there somehow is a difference in amount of hits with diagrams and without).
The "determine hits" as Manager should send another parallel request to get the diagram information.