### PR TITLE
feat(NUM-2293): List project docs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -55,7 +55,10 @@
       "disableOptimisticBPs": true,
       "cwd": "${workspaceFolder}",
       "runtimeExecutable": "npm",
-      "args": ["run", "test", "--", "--runInBand", "--watchAll=false"]
+      "args": ["run", "test", "--", "--runInBand", "--watchAll=false"],
+      "env": {
+        "TZ": "UTC"
+      }
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "Start Dev Server",
       "type": "shell",
-      "command": ["npm", "start"],
+      "command": ["npm", "run", "start:hmr"],
       "isBackground": true,
       "group": {
         "isDefault": true,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "Start Dev Server",
       "type": "shell",
-      "command": ["npm", "run", "start:hmr"],
+      "command": ["npm", "run", "start"],
       "isBackground": true,
       "group": {
         "isDefault": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "num-portal-webapp",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "num-portal-webapp",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "hasInstallScript": true,
       "dependencies": {
         "@angular-devkit/build-angular": "^13.1.1",

--- a/src/app/modules/projects/components/project-editor-accordion/project-editor-accordion.component.html
+++ b/src/app/modules/projects/components/project-editor-accordion/project-editor-accordion.component.html
@@ -25,6 +25,7 @@
   ></num-project-editor-cohort-builder>
 
   <num-project-editor-general-info
+    [attachments]="project.attachments"
     [form]="projectForm"
     [isDisabled]="isGeneralInfoDisabled"
     [generalInfoData]="generalInfoData"

--- a/src/app/modules/projects/components/project-editor-general-info/project-editor-general-info.component.html
+++ b/src/app/modules/projects/components/project-editor-general-info/project-editor-general-info.component.html
@@ -162,6 +162,13 @@
       </section>
 
       <section role="presentation" class="num-margin-b-10">
+        <num-attachments-table
+          [attachments]="attachments"
+          [viewMode]="false"
+        ></num-attachments-table>
+      </section>
+
+      <section role="presentation" class="num-margin-b-10">
         <p class="mat-display-4 num-margin-b-10">{{ 'FORM.FINANCED' | translate }}</p>
         <mat-slide-toggle
           formControlName="financed"

--- a/src/app/modules/projects/components/project-editor-general-info/project-editor-general-info.component.ts
+++ b/src/app/modules/projects/components/project-editor-general-info/project-editor-general-info.component.ts
@@ -20,6 +20,7 @@ import { IDefinitionList } from '../../../../shared/models/definition-list.inter
 import { DateAdapter } from '@angular/material/core'
 import { TranslateService } from '@ngx-translate/core'
 import { Subscription } from 'rxjs'
+import { ProjectAttachmentUiModel } from 'src/app/shared/models/project/project-attachment-ui.model'
 
 @Component({
   selector: 'num-project-editor-general-info',
@@ -29,6 +30,7 @@ import { Subscription } from 'rxjs'
 export class ProjectEditorGeneralInfoComponent implements OnInit, OnDestroy {
   constructor(private dateAdapter: DateAdapter<any>, private translate: TranslateService) {}
 
+  @Input() attachments: ProjectAttachmentUiModel[] = []
   @Input() form: FormGroup
   @Input() isDisabled: boolean
   @Input() generalInfoData: IDefinitionList[]

--- a/src/app/shared/components/attachments-table/attachments-table.component.html
+++ b/src/app/shared/components/attachments-table/attachments-table.component.html
@@ -68,13 +68,15 @@
       <td
         mat-cell
         *matCellDef="let element"
-        class="truncate"
+        numTooltipNecessary
+        matTooltipPosition="below"
         data-test="attachments-table__table-data__attachment-name"
       >
         {{ element.name }}
       </td>
     </ng-container>
 
+    <!-- Description column -->
     <ng-container matColumnDef="description">
       <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header>
         {{ 'PROJECT.ATTACHMENT.DESCRIPTION' | translate }}

--- a/src/app/shared/components/attachments-table/attachments-table.component.html
+++ b/src/app/shared/components/attachments-table/attachments-table.component.html
@@ -35,6 +35,7 @@
           (change)="$event ? masterToggle() : null"
           [checked]="selection.hasValue() && isAllSelected()"
           [indeterminate]="selection.hasValue() && !isAllSelected()"
+          data-test="attachments-table__select-all-toggle"
         ></mat-checkbox>
       </th>
       <td mat-cell *matCellDef="let row">
@@ -42,6 +43,7 @@
           (click)="$event.stopPropagation()"
           (change)="$event ? selection.toggle(row) : null"
           [checked]="selection.isSelected(row)"
+          [attr.data-test]="'attachments-table__select-row-toggle-' + row.id"
         ></mat-checkbox>
       </td>
     </ng-container>

--- a/src/app/shared/components/attachments-table/attachments-table.component.html
+++ b/src/app/shared/components/attachments-table/attachments-table.component.html
@@ -78,9 +78,11 @@
         {{ 'PROJECT.ATTACHMENT.DESCRIPTION' | translate }}
       </th>
       <td
+        #descriptionCell
         mat-cell
         *matCellDef="let element"
-        class="truncate"
+        numTooltipNecessary
+        matTooltipPosition="below"
         data-test="attachments-table__table-data__attachment-description"
       >
         {{ element.description }}

--- a/src/app/shared/components/attachments-table/attachments-table.component.html
+++ b/src/app/shared/components/attachments-table/attachments-table.component.html
@@ -1,0 +1,111 @@
+<!--
+ Copyright 2023 Vitagroup AG
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+      http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<p class="mat-display-4" id="attachments-header" *ngIf="viewMode === false">
+  {{ 'FORM.ATTACHMENTS' | translate }}
+</p>
+
+<div role="presentation" class="project-attachments-table-wrapper mat-elevation num-margin-b-60">
+  <table
+    aria-labelledby="attachments-header"
+    mat-table
+    [dataSource]="dataSource"
+    matSort
+    matSortActive="uploadDate"
+    fixedLayout
+    data-test="attachments__table"
+  >
+    <!-- Checkbox column -->
+    <ng-container matColumnDef="select">
+      <th scope="col" mat-header-cell *matHeaderCellDef class="width-sm" mat-header>
+        <mat-checkbox
+          (change)="$event ? masterToggle() : null"
+          [checked]="selection.hasValue() && isAllSelected()"
+          [indeterminate]="selection.hasValue() && !isAllSelected()"
+        ></mat-checkbox>
+      </th>
+      <td mat-cell *matCellDef="let row">
+        <mat-checkbox
+          (click)="$event.stopPropagation()"
+          (change)="$event ? selection.toggle(row) : null"
+          [checked]="selection.isSelected(row)"
+        ></mat-checkbox>
+      </td>
+    </ng-container>
+
+    <!-- ID column is only for default sorting and will not be displayed -->
+    <ng-container matColumnDef="id">
+      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header>ID</th>
+      <td
+        mat-cell
+        *matCellDef="let element"
+        data-test="attachments-table__table-data__attachment-id"
+      >
+        {{ element.id }}
+      </td>
+    </ng-container>
+
+    <!-- Filename column -->
+    <ng-container matColumnDef="name">
+      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header>
+        {{ 'PROJECT.ATTACHMENT.NAME' | translate }}
+      </th>
+      <td
+        mat-cell
+        *matCellDef="let element"
+        class="truncate"
+        data-test="attachments-table__table-data__attachment-name"
+      >
+        {{ element.name }}
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="description">
+      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header>
+        {{ 'PROJECT.ATTACHMENT.DESCRIPTION' | translate }}
+      </th>
+      <td
+        mat-cell
+        *matCellDef="let element"
+        class="truncate"
+        data-test="attachments-table__table-data__attachment-description"
+      >
+        {{ element.description }}
+      </td>
+    </ng-container>
+
+    <!-- Upload date column -->
+    <ng-container matColumnDef="uploadDate">
+      <th scope="col" mat-header-cell *matHeaderCellDef mat-sort-header>
+        {{ 'PROJECT.ATTACHMENT.UPLOAD_DATE' | translate }}
+      </th>
+      <td
+        mat-cell
+        *matCellDef="let element"
+        data-test="attachments-table__table-data__attachment-author"
+      >
+        {{ element.uploadDate | localizedDate }}
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr
+      mat-row
+      *matRowDef="let row; columns: displayedColumns"
+      (click)="selection.toggle(row)"
+    ></tr>
+  </table>
+</div>

--- a/src/app/shared/components/attachments-table/attachments-table.component.scss
+++ b/src/app/shared/components/attachments-table/attachments-table.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Vitagroup AG
+ * Copyright 2023 Vitagroup AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-export enum DefinitionType {
-  String = 'string',
-  Array = 'array',
-  Boolean = 'boolean',
-  Date = 'date',
-  Table = 'table',
+table {
+  width: 100%;
+
+  .truncate {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    padding-right: 5px;
+  }
 }

--- a/src/app/shared/components/attachments-table/attachments-table.component.scss
+++ b/src/app/shared/components/attachments-table/attachments-table.component.scss
@@ -17,9 +17,9 @@
 table {
   width: 100%;
 
-  .truncate {
-    text-overflow: ellipsis;
+  td {
     overflow: hidden;
-    padding-right: 5px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }

--- a/src/app/shared/components/attachments-table/attachments-table.component.spec.ts
+++ b/src/app/shared/components/attachments-table/attachments-table.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { AttachmentsTableComponent } from './attachments-table.component'
+
+describe('AttachmentsTableComponent', () => {
+  let component: AttachmentsTableComponent
+  let fixture: ComponentFixture<AttachmentsTableComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AttachmentsTableComponent],
+    }).compileComponents()
+  })
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AttachmentsTableComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/shared/components/attachments-table/attachments-table.component.spec.ts
+++ b/src/app/shared/components/attachments-table/attachments-table.component.spec.ts
@@ -1,24 +1,91 @@
+import { HarnessLoader } from '@angular/cdk/testing'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
-
+import { MatTableHarness } from '@angular/material/table/testing'
 import { AttachmentsTableComponent } from './attachments-table.component'
+import { attachmentApiMocks } from '../../../../mocks/data-mocks/project-attachment.mock'
+import { ProjectAttachmentUiModel } from '../../models/project/project-attachment-ui.model'
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed'
+import { MatTableModule } from '@angular/material/table'
+import { MatSortModule } from '@angular/material/sort'
+import { MatCheckboxModule } from '@angular/material/checkbox'
+import { MatTooltipModule } from '@angular/material/tooltip'
+import { Directive, Pipe, PipeTransform } from '@angular/core'
+import { TranslateModule } from '@ngx-translate/core'
+import { NoopAnimationsModule } from '@angular/platform-browser/animations'
+import { CommonModule } from '@angular/common'
+
+const attachmentUiMocks = attachmentApiMocks.map(
+  (attachmentApiMock) => new ProjectAttachmentUiModel(attachmentApiMock)
+)
 
 describe('AttachmentsTableComponent', () => {
   let component: AttachmentsTableComponent
   let fixture: ComponentFixture<AttachmentsTableComponent>
+  let harnessLoader: HarnessLoader
+
+  @Directive({
+    selector: '[numTooltipNecessary]',
+  })
+  class ToolTipNecessaryStubDirective {}
+
+  @Pipe({
+    name: 'localizedDate',
+  })
+  class MockLocalizedDatePipe implements PipeTransform {
+    transform(value: number): number {
+      return value
+    }
+  }
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [AttachmentsTableComponent],
+      declarations: [
+        AttachmentsTableComponent,
+        ToolTipNecessaryStubDirective,
+        MockLocalizedDatePipe,
+      ],
+      imports: [
+        CommonModule,
+        MatCheckboxModule,
+        MatSortModule,
+        MatTableModule,
+        MatTooltipModule,
+        NoopAnimationsModule,
+        TranslateModule.forRoot(),
+      ],
     }).compileComponents()
-  })
-
-  beforeEach(() => {
     fixture = TestBed.createComponent(AttachmentsTableComponent)
     component = fixture.componentInstance
+    harnessLoader = TestbedHarnessEnvironment.loader(fixture)
     fixture.detectChanges()
   })
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  describe('when a list of attachments have been loaded', () => {
+    beforeEach(() => {
+      component.attachments = attachmentUiMocks
+      fixture.detectChanges()
+    })
+
+    it('should show one row per attachment', async () => {
+      const table = await harnessLoader.getHarness(MatTableHarness)
+      const rows = await table.getRows()
+      expect(rows.length).toEqual(attachmentUiMocks.length)
+      rows.forEach(async (row, idx) => {
+        const { name, description } = await row.getCellTextByColumnName()
+        expect(name).toEqual(attachmentUiMocks[idx].name)
+        expect(description).toEqual(attachmentUiMocks[idx].description)
+      })
+    })
+
+    it('should also show select columns if view only mode is switched off', async () => {
+      component.viewMode = false
+      const table = await harnessLoader.getHarness(MatTableHarness)
+      const columns = await table.getCellTextByColumnName()
+      expect(Object.keys(columns)).toContain('select')
+    })
   })
 })

--- a/src/app/shared/components/attachments-table/attachments-table.component.spec.ts
+++ b/src/app/shared/components/attachments-table/attachments-table.component.spec.ts
@@ -1,18 +1,23 @@
-import { HarnessLoader } from '@angular/cdk/testing'
+import { CommonModule } from '@angular/common'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
-import { MatTableHarness } from '@angular/material/table/testing'
-import { AttachmentsTableComponent } from './attachments-table.component'
-import { attachmentApiMocks } from '../../../../mocks/data-mocks/project-attachment.mock'
+import { Directive, Pipe, PipeTransform } from '@angular/core'
+import { HarnessLoader } from '@angular/cdk/testing'
+import { MatCheckboxModule } from '@angular/material/checkbox'
+import { MatCheckboxHarness } from '@angular/material/checkbox/testing'
+import { MatSortModule } from '@angular/material/sort'
+import {
+  MatTableHarness,
+  MatCellHarness,
+  MatHeaderCellHarness,
+} from '@angular/material/table/testing'
+import { MatTableModule } from '@angular/material/table'
+import { MatTooltipModule } from '@angular/material/tooltip'
+import { NoopAnimationsModule } from '@angular/platform-browser/animations'
 import { ProjectAttachmentUiModel } from '../../models/project/project-attachment-ui.model'
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed'
-import { MatTableModule } from '@angular/material/table'
-import { MatSortModule } from '@angular/material/sort'
-import { MatCheckboxModule } from '@angular/material/checkbox'
-import { MatTooltipModule } from '@angular/material/tooltip'
-import { Directive, Pipe, PipeTransform } from '@angular/core'
 import { TranslateModule } from '@ngx-translate/core'
-import { NoopAnimationsModule } from '@angular/platform-browser/animations'
-import { CommonModule } from '@angular/common'
+import { attachmentApiMocks } from '../../../../mocks/data-mocks/project-attachment.mock'
+import { AttachmentsTableComponent } from './attachments-table.component'
 
 const attachmentUiMocks = attachmentApiMocks.map(
   (attachmentApiMock) => new ProjectAttachmentUiModel(attachmentApiMock)
@@ -86,6 +91,55 @@ describe('AttachmentsTableComponent', () => {
       const table = await harnessLoader.getHarness(MatTableHarness)
       const columns = await table.getCellTextByColumnName()
       expect(Object.keys(columns)).toContain('select')
+    })
+  })
+
+  describe('when selecting rows from table', () => {
+    beforeEach(() => {
+      component.attachments = attachmentUiMocks
+      component.viewMode = false
+      fixture.detectChanges()
+    })
+
+    it('should (de)select single rows using the checkbox', async () => {
+      const firstSelect = await harnessLoader.getHarness(
+        MatCellHarness.with({ columnName: 'select' })
+      )
+      const checkbox = await firstSelect.getHarness(MatCheckboxHarness)
+      await checkbox.toggle()
+      expect(component.selection.selected.length).toEqual(1)
+      expect(component.selection.selected).toContain(attachmentUiMocks[0])
+      await checkbox.toggle()
+      expect(component.selection.selected).not.toContain(attachmentUiMocks[0])
+    })
+
+    it('should (de)select all rows if none has been selected before', async () => {
+      const masterSelect = await harnessLoader.getHarness(
+        MatHeaderCellHarness.with({ columnName: 'select' })
+      )
+      const checkbox = await masterSelect.getHarness(MatCheckboxHarness)
+      await checkbox.toggle()
+      expect(component.selection.selected.length).toEqual(attachmentUiMocks.length)
+      expect(component.isAllSelected()).toEqual(true)
+      await checkbox.toggle()
+      expect(component.selection.selected.length).toEqual(0)
+      expect(component.isAllSelected()).toEqual(false)
+    })
+
+    it('should select all rows if only partial rows have been selected before', async () => {
+      const selects = await harnessLoader.getAllHarnesses(
+        MatCellHarness.with({ columnName: 'select' })
+      )
+      const firstCheckbox = await selects[0].getHarness(MatCheckboxHarness)
+      const thirdCheckbox = await selects[2].getHarness(MatCheckboxHarness)
+      await Promise.all([firstCheckbox.toggle(), thirdCheckbox.toggle()])
+      expect(component.selection.selected.length).toEqual(2)
+      const masterSelect = await harnessLoader.getHarness(
+        MatHeaderCellHarness.with({ columnName: 'select' })
+      )
+      const masterToggleCheckbox = await masterSelect.getHarness(MatCheckboxHarness)
+      await masterToggleCheckbox.toggle()
+      expect(component.selection.selected.length).toEqual(attachmentUiMocks.length)
     })
   })
 })

--- a/src/app/shared/components/attachments-table/attachments-table.component.ts
+++ b/src/app/shared/components/attachments-table/attachments-table.component.ts
@@ -52,13 +52,38 @@ export class AttachmentsTableComponent extends SortableTable<ProjectAttachmentUi
     this.selection = new SelectionModel<ProjectAttachmentUiModel>(true, [])
   }
 
-  isAllSelected() {
+  /**
+   * Checks whether all attachment elements from table have been selected by checking the count of
+   * total selected rows and the total count of rows.
+   *
+   * @returns true if all attachments have been selected false otherwise
+   */
+  isAllSelected(): boolean {
     const numSelected = this.selection.selected.length
     const numRows = this.dataSource.data.length
     return numSelected === numRows
   }
 
+  /**
+   * If all attachments have been selected this method will deselect all of them. In all other
+   * cases all elements will be selected.
+   */
   masterToggle() {
     this.isAllSelected() ? this.selection.clear() : this.selection.select(...this.dataSource.data)
+  }
+
+  /**
+   * Inspect a given html element and check if the scrollable text content exceeds the overall
+   * dimensions of the element. If the content remains within the boundaries this will return
+   * 'true' meaning the tooltip can be disabled. In all other cases null will be returned which
+   * in html will be interpreted as the attribute is not set at all.
+   *
+   * @param {HTMLElement} elem - Target element to inspect
+   * @returns true if tooltip is not necessary or null if it has to be shown
+   */
+  isTooltipDisabled(elem: HTMLElement): true | null {
+    return elem.scrollWidth <= elem.clientWidth && elem.scrollHeight <= elem.clientHeight
+      ? true
+      : null
   }
 }

--- a/src/app/shared/components/attachments-table/attachments-table.component.ts
+++ b/src/app/shared/components/attachments-table/attachments-table.component.ts
@@ -71,19 +71,4 @@ export class AttachmentsTableComponent extends SortableTable<ProjectAttachmentUi
   masterToggle() {
     this.isAllSelected() ? this.selection.clear() : this.selection.select(...this.dataSource.data)
   }
-
-  /**
-   * Inspect a given html element and check if the scrollable text content exceeds the overall
-   * dimensions of the element. If the content remains within the boundaries this will return
-   * 'true' meaning the tooltip can be disabled. In all other cases null will be returned which
-   * in html will be interpreted as the attribute is not set at all.
-   *
-   * @param {HTMLElement} elem - Target element to inspect
-   * @returns true if tooltip is not necessary or null if it has to be shown
-   */
-  isTooltipDisabled(elem: HTMLElement): true | null {
-    return elem.scrollWidth <= elem.clientWidth && elem.scrollHeight <= elem.clientHeight
-      ? true
-      : null
-  }
 }

--- a/src/app/shared/components/attachments-table/attachments-table.component.ts
+++ b/src/app/shared/components/attachments-table/attachments-table.component.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2023 Vitagroup AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Input, ViewChild } from '@angular/core'
+import { ProjectAttachmentUiModel } from '../../models/project/project-attachment-ui.model'
+import { SortableTable } from '../../models/sortable-table.model'
+import { MatSort } from '@angular/material/sort'
+import { SelectionModel } from '@angular/cdk/collections'
+
+@Component({
+  selector: 'num-attachments-table',
+  templateUrl: './attachments-table.component.html',
+  styleUrls: ['./attachments-table.component.scss'],
+})
+export class AttachmentsTableComponent extends SortableTable<ProjectAttachmentUiModel> {
+  @Input()
+  set attachments(attachments: ProjectAttachmentUiModel[]) {
+    this.dataSource.data = attachments
+  }
+  @Input()
+  set viewMode(mode: boolean) {
+    if (!mode) {
+      this.displayedColumns.unshift('select')
+    }
+  }
+
+  @ViewChild(MatSort) set matSort(sort: MatSort) {
+    this.dataSource.sort = sort
+  }
+  displayedColumns: (keyof ProjectAttachmentUiModel | 'select')[] = [
+    'name',
+    'description',
+    'uploadDate',
+  ]
+
+  selection: SelectionModel<ProjectAttachmentUiModel>
+
+  constructor() {
+    super()
+    this.selection = new SelectionModel<ProjectAttachmentUiModel>(true, [])
+  }
+
+  isAllSelected() {
+    const numSelected = this.selection.selected.length
+    const numRows = this.dataSource.data.length
+    return numSelected === numRows
+  }
+
+  masterToggle() {
+    this.isAllSelected() ? this.selection.clear() : this.selection.select(...this.dataSource.data)
+  }
+}

--- a/src/app/shared/components/definition-list/definition-list.component.html
+++ b/src/app/shared/components/definition-list/definition-list.component.html
@@ -23,12 +23,19 @@
       }}</ng-container>
 
       <ng-container *ngIf="dataRow?.type === definitionType.Array">
-        <ng-container *ngIf="dataRow?.description?.length === 0"> - </ng-container>
-
-        <ng-container *ngIf="dataRow?.description?.length !== 0">
+        <ng-container *ngIf="dataRow?.description?.length !== 0; else emptyIterable">
           <span class="num-display-chip" *ngFor="let chip of dataRow.description">{{
             dataRow.title !== 'FORM.CATEGORY' ? chip : ('PROJECT.CATEGORIES.' + chip | translate)
           }}</span>
+        </ng-container>
+      </ng-container>
+
+      <ng-container *ngIf="dataRow?.type === definitionType.Table">
+        <ng-container *ngIf="dataRow?.description?.length > 0; else emptyIterable">
+          <num-attachments-table
+            [attachments]="dataRow?.description"
+            [viewMode]="true"
+          ></num-attachments-table>
         </ng-container>
       </ng-container>
 
@@ -52,3 +59,7 @@
     </dd>
   </ng-container>
 </dl>
+
+<ng-template #emptyIterable>
+  <ng-container> - </ng-container>
+</ng-template>

--- a/src/app/shared/components/shared-components.module.ts
+++ b/src/app/shared/components/shared-components.module.ts
@@ -32,6 +32,7 @@ import { TimeInputComponent } from './time-input/time-input.component'
 import { EditorDetermineHitsComponent } from './editor-determine-hits/editor-determine-hits.component'
 import { AqlParameterInputsComponent } from './aql-parameter-inputs/aql-parameter-inputs.component'
 import { ResultTableComponent } from './result-table/result-table.component'
+import { AttachmentsTableComponent } from './attachments-table/attachments-table.component'
 
 const SHARED_DECLARATIONS = [
   SearchComponent,
@@ -44,6 +45,7 @@ const SHARED_DECLARATIONS = [
   EditorDetermineHitsComponent,
   AqlParameterInputsComponent,
   ResultTableComponent,
+  AttachmentsTableComponent,
 ]
 
 @NgModule({

--- a/src/app/shared/components/shared-components.module.ts
+++ b/src/app/shared/components/shared-components.module.ts
@@ -33,6 +33,7 @@ import { EditorDetermineHitsComponent } from './editor-determine-hits/editor-det
 import { AqlParameterInputsComponent } from './aql-parameter-inputs/aql-parameter-inputs.component'
 import { ResultTableComponent } from './result-table/result-table.component'
 import { AttachmentsTableComponent } from './attachments-table/attachments-table.component'
+import { DirectivesModule } from '../directives/directives.module'
 
 const SHARED_DECLARATIONS = [
   SearchComponent,
@@ -59,6 +60,7 @@ const SHARED_DECLARATIONS = [
     ReactiveFormsModule,
     TranslateModule,
     PipesModule,
+    DirectivesModule,
   ],
   exports: SHARED_DECLARATIONS,
 })

--- a/src/app/shared/directives/directives.module.ts
+++ b/src/app/shared/directives/directives.module.ts
@@ -17,10 +17,11 @@
 import { CommonModule } from '@angular/common'
 import { NgModule } from '@angular/core'
 import { UserHasRoleDirective } from './user-has-role.directive'
+import { TooltipNecessaryDirective } from './tooltip-necessary/tooltip-necessary.directive'
 
 @NgModule({
-  declarations: [UserHasRoleDirective],
+  declarations: [UserHasRoleDirective, TooltipNecessaryDirective],
   imports: [CommonModule],
-  exports: [UserHasRoleDirective],
+  exports: [UserHasRoleDirective, TooltipNecessaryDirective],
 })
 export class DirectivesModule {}

--- a/src/app/shared/directives/tooltip-necessary/tooltip-necessary.directive.spec.ts
+++ b/src/app/shared/directives/tooltip-necessary/tooltip-necessary.directive.spec.ts
@@ -1,0 +1,88 @@
+import { Component, ElementRef, Input, ViewChild } from '@angular/core'
+import { TooltipNecessaryDirective } from './tooltip-necessary.directive'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { MatTooltipModule } from '@angular/material/tooltip'
+import { By } from '@angular/platform-browser'
+
+describe('TooltipNecessaryDirective', () => {
+  let fixture: ComponentFixture<TestTooltipNecessaryComponent>
+  let component: TestTooltipNecessaryComponent
+  @Component({
+    template: `<p #testParagraph numTooltipNecessary>{{ textContent }}</p>`,
+    styles: [
+      `
+        p {
+          max-width: 20px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+      `,
+    ],
+  })
+  class TestTooltipNecessaryComponent {
+    @Input() textContent = ''
+    @ViewChild('testParagraph') testElement: ElementRef<HTMLParagraphElement>
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TestTooltipNecessaryComponent, TooltipNecessaryDirective],
+      imports: [MatTooltipModule],
+    }).compileComponents()
+    fixture = TestBed.createComponent(TestTooltipNecessaryComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should not append a tooltip if text content fits into element', () => {
+    component.textContent = 'short text'
+    Object.defineProperty(component.testElement.nativeElement, 'offsetWidth', { value: 20 })
+    Object.defineProperty(component.testElement.nativeElement, 'scrollWidth', {
+      value: component.textContent.length,
+    })
+    fixture.detectChanges()
+    const directiveElement = fixture.debugElement.query(By.directive(TooltipNecessaryDirective))
+    directiveElement.triggerEventHandler('mouseenter', null)
+
+    const tooltip = fixture.debugElement.query(By.css('.mat-tooltip-trigger'))
+    expect(tooltip).toBeFalsy()
+  })
+
+  it('should append a tooltip if text content exceeds element width', () => {
+    component.textContent =
+      'This is a very long text that should exceed definitely the content max width'
+    Object.defineProperty(component.testElement.nativeElement, 'offsetWidth', { value: 20 })
+    Object.defineProperty(component.testElement.nativeElement, 'scrollWidth', {
+      value: component.textContent.length,
+    })
+    fixture.detectChanges()
+    const directiveElement = fixture.debugElement.query(By.directive(TooltipNecessaryDirective))
+    directiveElement.triggerEventHandler('mouseenter', null)
+    fixture.detectChanges()
+
+    const toolTip = fixture.debugElement.query(By.css('[mattooltip]'))
+    expect(toolTip).toBeTruthy()
+    expect((toolTip.nativeElement as HTMLElement).textContent).toEqual(component.textContent)
+  })
+
+  it('should remove a tooltip if mouse leaves the element', () => {
+    component.textContent =
+      'This is a very long text that should exceed definitely the content max width'
+    Object.defineProperty(component.testElement.nativeElement, 'offsetWidth', { value: 20 })
+    Object.defineProperty(component.testElement.nativeElement, 'scrollWidth', {
+      value: component.textContent.length,
+    })
+    fixture.detectChanges()
+    const directiveElement = fixture.debugElement.query(By.directive(TooltipNecessaryDirective))
+    directiveElement.triggerEventHandler('mouseenter', null)
+    fixture.detectChanges()
+
+    let toolTip = fixture.debugElement.query(By.css('[mattooltip]'))
+    expect(toolTip).toBeTruthy()
+    directiveElement.triggerEventHandler('mouseleave', null)
+    fixture.detectChanges()
+    toolTip = fixture.debugElement.query(By.css('[mattooltip]'))
+    expect(toolTip).toBeFalsy()
+  })
+})

--- a/src/app/shared/directives/tooltip-necessary/tooltip-necessary.directive.ts
+++ b/src/app/shared/directives/tooltip-necessary/tooltip-necessary.directive.ts
@@ -1,0 +1,32 @@
+import { Directive, ElementRef, HostListener, Renderer2 } from '@angular/core'
+import { MatTooltip } from '@angular/material/tooltip'
+
+@Directive({
+  selector: '[numTooltipNecessary]',
+  providers: [MatTooltip],
+})
+export class TooltipNecessaryDirective {
+  private htmlElement: HTMLElement
+  constructor(
+    private elementRef: ElementRef,
+    private renderer: Renderer2,
+    private tooltip: MatTooltip
+  ) {
+    this.htmlElement = this.elementRef.nativeElement
+  }
+
+  @HostListener('mouseenter')
+  mouseEnter(): void {
+    if (this.htmlElement.offsetWidth < this.htmlElement.scrollWidth) {
+      this.renderer.setAttribute(this.htmlElement, 'matTooltip', this.htmlElement.textContent)
+      this.tooltip.message = this.htmlElement.textContent
+      this.tooltip.show()
+    }
+  }
+
+  @HostListener('mouseleave')
+  mouseLeave(): void {
+    this.tooltip.hide()
+    this.renderer.removeAttribute(this.htmlElement, 'matTooltip')
+  }
+}

--- a/src/app/shared/models/definition-list.interface.ts
+++ b/src/app/shared/models/definition-list.interface.ts
@@ -15,9 +15,10 @@
  */
 
 import { DefinitionType } from './definition-type.enum'
+import { ProjectAttachmentUiModel } from './project/project-attachment-ui.model'
 
 export interface IDefinitionList {
   title: string
-  description: string | string[] | boolean | Date
+  description: string | string[] | ProjectAttachmentUiModel[] | boolean | Date
   type?: DefinitionType
 }

--- a/src/app/shared/models/project/project-api.interface.ts
+++ b/src/app/shared/models/project/project-api.interface.ts
@@ -19,6 +19,7 @@ import { IProjectUser } from '../user/project-user.interface'
 import { IUser } from '../user/user.interface'
 import { ProjectStatus } from './project-status.enum'
 import { IProjectTemplateInfoApi } from './project-template-info-api.interface'
+import { IProjectAttachmentApi } from './project-attachment-api.interface'
 
 export interface IProjectApi {
   cohortId?: number
@@ -41,4 +42,5 @@ export interface IProjectApi {
   researchers?: IProjectUser[]
   status?: ProjectStatus
   templates?: IProjectTemplateInfoApi[]
+  attachments?: IProjectAttachmentApi[]
 }

--- a/src/app/shared/models/project/project-attachment-api.interface.ts
+++ b/src/app/shared/models/project/project-attachment-api.interface.ts
@@ -1,0 +1,23 @@
+export interface IProjectAttachmentApi {
+  /**
+   * Unique ID of this attachment
+   */
+  id: number
+  /**
+   * File name of the attachment
+   */
+  name: string
+  /**
+   * Optional description for the attachment
+   */
+  description?: string
+  /**
+   * Date of upload in full ISO 6801 format string, i.e. YYYY-MM-DDTHH.mm.ss.SSSZ
+   */
+  uploadDate: string
+  /**
+   * Review counter of the document providing the document has been reviewed and thus should no
+   * longer be editable.
+   */
+  reviewCounter: number
+}

--- a/src/app/shared/models/project/project-attachment-ui.model.spec.ts
+++ b/src/app/shared/models/project/project-attachment-ui.model.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2023 Vitagroup AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  attachmentApiMock1,
+  attachmentApiMock2,
+} from 'src/mocks/data-mocks/project-attachment.mock'
+import { ProjectAttachmentUiModel } from './project-attachment-ui.model'
+
+describe('ProjectAttachmentUiModel', () => {
+  it('should parse all values as expected to ui model', () => {
+    const uiModel = new ProjectAttachmentUiModel(attachmentApiMock1)
+    expect(uiModel.id).toEqual(attachmentApiMock1.id)
+    expect(uiModel.name).toEqual(attachmentApiMock1.name)
+    expect(uiModel.reviewCounter).toEqual(attachmentApiMock1.reviewCounter)
+    expect(uiModel.description).toEqual(attachmentApiMock1.description)
+    expect(uiModel.uploadDate).toBeInstanceOf(Date)
+    expect(uiModel.uploadDate).toEqual(new Date(attachmentApiMock1.uploadDate))
+  })
+
+  it('should parse all values as expected to api model', () => {
+    const uiModel = new ProjectAttachmentUiModel(attachmentApiMock2)
+    expect(uiModel.convertToApi()).toEqual({
+      ...attachmentApiMock2,
+      uploadDate: new Date(attachmentApiMock2.uploadDate).toISOString(),
+    })
+  })
+})

--- a/src/app/shared/models/project/project-attachment-ui.model.ts
+++ b/src/app/shared/models/project/project-attachment-ui.model.ts
@@ -1,0 +1,17 @@
+import { IProjectAttachmentApi } from './project-attachment-api.interface'
+
+export class ProjectAttachmentUiModel {
+  id: number
+  name: string
+  description?: string
+  uploadDate: Date
+  reviewCounter: number
+
+  constructor({ id, name, reviewCounter, uploadDate, description }: IProjectAttachmentApi) {
+    this.id = id
+    this.name = name
+    this.reviewCounter = reviewCounter
+    this.uploadDate = new Date(uploadDate)
+    this.description = description
+  }
+}

--- a/src/app/shared/models/project/project-attachment-ui.model.ts
+++ b/src/app/shared/models/project/project-attachment-ui.model.ts
@@ -14,4 +14,16 @@ export class ProjectAttachmentUiModel {
     this.uploadDate = new Date(uploadDate)
     this.description = description
   }
+
+  convertToApi(): IProjectAttachmentApi {
+    const { id, name, reviewCounter, description, uploadDate } = this
+
+    return {
+      id,
+      name,
+      reviewCounter,
+      description,
+      uploadDate: uploadDate.toISOString(),
+    }
+  }
 }

--- a/src/app/shared/models/project/project-ui.model.ts
+++ b/src/app/shared/models/project/project-ui.model.ts
@@ -27,6 +27,7 @@ import { IProjectApi } from './project-api.interface'
 import { ProjectStatus } from './project-status.enum'
 import { IProjectTemplateInfoApi } from './project-template-info-api.interface'
 import moment from 'moment'
+import { ProjectAttachmentUiModel } from './project-attachment-ui.model'
 
 export class ProjectUiModel {
   cohortId: number | null
@@ -51,6 +52,7 @@ export class ProjectUiModel {
   researchersApi: IProjectUser[]
   status: ProjectStatus
   templates: IProjectTemplateInfoApi[]
+  attachments: ProjectAttachmentUiModel[] = []
 
   constructor(projectApi?: IProjectApi) {
     this.id = projectApi?.id || null
@@ -77,6 +79,9 @@ export class ProjectUiModel {
     this.researchersApi = projectApi?.researchers || []
     this.templates = projectApi?.templates || []
     this.cohortGroup = new CohortGroupUiModel()
+    this.attachments = projectApi.attachments.map(
+      (attachment) => new ProjectAttachmentUiModel(attachment)
+    )
   }
 
   addCohortGroup(cohortGroup?: ICohortGroupApi): void {

--- a/src/app/shared/models/project/project-ui.model.ts
+++ b/src/app/shared/models/project/project-ui.model.ts
@@ -80,7 +80,7 @@ export class ProjectUiModel {
     this.templates = projectApi?.templates || []
     this.cohortGroup = new CohortGroupUiModel()
     this.attachments =
-      projectApi.attachments?.map((attachment) => new ProjectAttachmentUiModel(attachment)) || []
+      projectApi?.attachments?.map((attachment) => new ProjectAttachmentUiModel(attachment)) || []
   }
 
   addCohortGroup(cohortGroup?: ICohortGroupApi): void {

--- a/src/app/shared/models/project/project-ui.model.ts
+++ b/src/app/shared/models/project/project-ui.model.ts
@@ -79,9 +79,8 @@ export class ProjectUiModel {
     this.researchersApi = projectApi?.researchers || []
     this.templates = projectApi?.templates || []
     this.cohortGroup = new CohortGroupUiModel()
-    this.attachments = projectApi.attachments.map(
-      (attachment) => new ProjectAttachmentUiModel(attachment)
-    )
+    this.attachments =
+      projectApi.attachments?.map((attachment) => new ProjectAttachmentUiModel(attachment)) || []
   }
 
   addCohortGroup(cohortGroup?: ICohortGroupApi): void {
@@ -148,6 +147,11 @@ export class ProjectUiModel {
         title: 'FORM.END_DATE',
         description: this.endDate || undefined,
         type: DefinitionType.Date,
+      },
+      {
+        title: 'FORM.ATTACHMENTS',
+        description: this.attachments || [],
+        type: DefinitionType.Table,
       },
       {
         title: 'FORM.FINANCED_BY_PRIVATE',

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -143,7 +143,6 @@
     "PRIVACY_PRIVATE": "Nur mit mir",
     "PRIVACY_PUBLIC": "Öffentlich",
     "CATEGORY_NOT_DELETABLE": "Kategorien mit zugewiesenen Kriterien können nicht gelöscht werden."
-
   },
   "CONTENT_EDITOR": {
     "SAVE_NAVIGATION_SUCCESS": "Die Navigationselemente wurden erfolgreich veröffentlicht.",
@@ -246,7 +245,8 @@
     "ORGANIZATION_NAME_PLACEHOLDER": "Name der Organisation eingeben",
     "ADD_ORGANIZATION_DOMAIN": "Mail-Domäne hinzufügen (domain part)",
     "ADD_ORGANIZATION_DOMAIN_PLACEHOLDER": "Z.B. domain.de or sub.domain.de",
-    "PSEUDONYM_PROJECT_ID": "Projekt-Id"
+    "PSEUDONYM_PROJECT_ID": "Projekt-Id",
+    "ATTACHMENTS": "Anhänge"
   },
   "BUTTON": {
     "ARCHIVE": "Archivieren",
@@ -373,6 +373,11 @@
       "RETROSPECTIVE_STUDY": "Retrospektive Projekt",
       "REGISTRY": "Register"
     },
+    "ATTACHMENT": {
+      "NAME": "Dateiname",
+      "DESCRIPTION": "Beschreibung",
+      "UPLOAD_DATE": "Datum"
+    },
     "CATEGORIES_NO_RESULTS": "Keine Ergebnisse",
     "CHANGE_STATUS_SUCCESS": "Der Projektstatus wurde erfolgreich aktualisiert.",
     "CHANGE_STATUS_ERROR": "Der Projektstatus konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut.",
@@ -387,6 +392,7 @@
     "DESCRIPTION_PLACEHOLDER": "Bitte verfassen Sie eine Projektbeschreibung",
     "GOAL_PLACEHOLDER": "Bitte geben Sie das Ziel des Projekts ein"
   },
+ 
   "USER": {
     "FIRST_NAME": "Vorname",
     "LAST_NAME": "Nachname",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -244,7 +244,8 @@
     "ORGANIZATION_NAME_PLACEHOLDER": "Enter organization name",
     "ADD_ORGANIZATION_DOMAIN": "Add mail domain (domain part)",
     "ADD_ORGANIZATION_DOMAIN_PLACEHOLDER": "E.g. domain.de or sub.domain.de",
-    "PSEUDONYM_PROJECT_ID": "Project-id"
+    "PSEUDONYM_PROJECT_ID": "Project-id",
+    "ATTACHMENTS": "Attachments"
   },
   "BUTTON": {
     "ARCHIVE": "Archive",
@@ -370,6 +371,11 @@
       "PROSPECTIVE_STUDY": "Prospective project",
       "RETROSPECTIVE_STUDY": "Retrospective project",
       "REGISTRY": "Registry"
+    },
+    "ATTACHMENT": {
+      "NAME": "Filename",
+      "DESCRIPTION": "Description",
+      "UPLOAD_DATE": "Date"
     },
     "CATEGORIES_NO_RESULTS": "No Results",
     "CHANGE_STATUS_SUCCESS": "The status of the project has been updated successfully.",

--- a/src/mocks/data-mocks/project-attachment.mock.ts
+++ b/src/mocks/data-mocks/project-attachment.mock.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2023 Vitagroup AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { IProjectAttachmentApi } from '../../app/shared/models/project/project-attachment-api.interface'
+import { generateRandomId } from '../mock-utils/mock-generator.utils'
+
+export const attachmentApiMock1: IProjectAttachmentApi = {
+  id: generateRandomId(),
+  name: 'CHEESECAKE-IPSUM.pdf',
+  description: 'Cupcake Ipsum',
+  uploadDate: '2023-11-24T14:54:08.475001Z',
+  reviewCounter: 0,
+}
+export const attachmentApiMock2: IProjectAttachmentApi = {
+  id: generateRandomId(),
+  name: 'LOREM-IPSUM.pdf',
+  description: 'Lorem Ipsum',
+  uploadDate: '2023-11-24T14:54:08.539756Z',
+  reviewCounter: 0,
+}
+
+export const attachmentApiMock3: IProjectAttachmentApi = {
+  id: generateRandomId(),
+  name: 'BACON-IPSUM.pdf',
+  description: 'Bacon Ipsum',
+  uploadDate: '2023-11-24T14:54:08.579344Z',
+  reviewCounter: 0,
+}
+
+export const attachmentApiMock4: IProjectAttachmentApi = {
+  id: generateRandomId(),
+  name: 'BACON-IPSUM-FILLER.pdf',
+  description: 'Bacon Ipsum with filler',
+  uploadDate: '2023-11-24T14:54:08.616182Z',
+  reviewCounter: 0,
+}
+
+export const attachmentApiMock5: IProjectAttachmentApi = {
+  id: generateRandomId(),
+  name: 'W3.ORG-DUMMY.pdf',
+  description: 'W3.org dummy PDF file',
+  uploadDate: '2023-11-24T14:39:51.858193Z',
+  reviewCounter: 0,
+}
+
+export const attachmentApiMocks = [
+  attachmentApiMock1,
+  attachmentApiMock2,
+  attachmentApiMock3,
+  attachmentApiMock4,
+  attachmentApiMock5,
+]

--- a/src/mocks/mock-utils/mock-generator.utils.ts
+++ b/src/mocks/mock-utils/mock-generator.utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2023 Vitagroup AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Generates a random number between 0 and maxValue as a integer id value. Uses {@link Math.random}
+ * for generation.
+ *
+ * @param maxValue - Maximum random value
+ * @returns - Random number between 0 and maxValue.
+ */
+export const generateRandomId = (maxValue = 1_000) => {
+  return Math.random() * maxValue
+}


### PR DESCRIPTION
## Changes

This PR adds the feature of showing attachments which were uploaded to a project in a table. Attachments were shown with their file name, description and upload date and with an selection column if the project has been opened in "edit mode".

The description and file name will be truncated and a tool-tip will be shown when hovering if the text is too long to be shown in the table cell.

## Related issues

User Story: [NUM-2291: Enable adding of attachments for data use project in the UI [E008-003]](https://vitagroup-ag.atlassian.net/browse/NUM-2291)
Sub-Task: [NUM-2293: FE | Attachments are listed on the project page]8https://vitagroup-ag.atlassian.net/browse/NUM-2293)