### PR TITLE
NUM-2306: Upgrade & fix build pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ workflows:
 jobs:
   security_scan:
     docker:
-      - image: cimg/openjdk:16.0.0-node
+      - image: cimg/openjdk:17.0.10-node
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.13
+          version: docker23
           docker_layer_caching: true
       - run:
           name: Build and tag image and push


### PR DESCRIPTION
## Changes

This PR updates CircleCI pipeline images and docker engine to support the required features of our pipelines.

The security scan image uses Ubuntu 22.03 which should include the `envsubst` command required for NPM setup. The update of the deprecated remote docker engine should add support for node versions above 16.13. which is demanded by our packages.