### PR TITLE
NUM-2306: Fix CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ jobs:
             else
               TAG="$(echo $CIRCLE_BRANCH | awk -F'/' '{print $2;}')-rc$CIRCLE_BUILD_NUM"
             fi
-            docker build -t $DOCKER_USER/num-portal-webapp:$TAG .
+            docker build --build-arg FONTAWESOME_NPM_AUTH_TOKEN=$FONTAWESOME_NPM_AUTH_TOKEN -t $DOCKER_USER/num-portal-webapp:$TAG .
             echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
             docker push $DOCKER_USER/num-portal-webapp:$TAG
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ README.md
 .gitignore
 .editorconfig
 .circleci
+# Required for NPM install
+!.circleci/.npmrc
 
 # IDEs and editors
 /.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 FROM node:16.20-alpine AS build
 WORKDIR /usr/src/app
 COPY . .
-ENV FONTAWESOME_NPM_AUTH_TOKEN=
+ARG FONTAWESOME_NPM_AUTH_TOKEN=
 RUN cp ./.circleci/.npmrc .
 RUN envsubst '$FONTAWESOME_NPM_AUTH_TOKEN' < ./.npmrc
 RUN npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,17 @@
 # limitations under the License.
 
 ### STAGE 1: Build ###
-FROM node:16-alpine3.11 AS build
+FROM node:16.20-alpine AS build
 WORKDIR /usr/src/app
 COPY . .
+ENV FONTAWESOME_NPM_AUTH_TOKEN=
+RUN cp ./.circleci/.npmrc .
+RUN envsubst '$FONTAWESOME_NPM_AUTH_TOKEN' < ./.npmrc
 RUN npm install
 ARG ENVIRONMENT=deploy
 RUN npm run build -- --configuration=${ENVIRONMENT}
 
 ### STAGE 2: Run ###
-FROM nginx:1.21.0-alpine
+FROM nginx:1.25-alpine
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY --from=build /usr/src/app/dist/num-portal-webapp /usr/share/nginx/html


### PR DESCRIPTION
## Changes

This PR adds the handling of Fortawesome token for the NPM registry so the docker build command is capable of using the token to fetch current dependencies.

Another addition is the usage of a new version of the remove docker engine whereas the old one was deprecated.

In addition the nginx version has been increased to the latest stable version.