### PR TITLE
Redirect to the login page instead of the logout page, when the user is already logged out

### DIFF
--- a/src/app/core/interceptors/error.interceptor.spec.ts
+++ b/src/app/core/interceptors/error.interceptor.spec.ts
@@ -9,7 +9,7 @@ describe('ErrorInterceptor', () => {
   let errorInterceptor: ErrorInterceptor
 
   const authService = {
-    logout: () => {},
+    login: () => {},
   } as AuthService
 
   const profileService = {
@@ -47,12 +47,12 @@ describe('ErrorInterceptor', () => {
         const mockErrorResponse = { status: 401, statusText: 'Unauthorized' }
         const data = 'Unauthorized'
 
-        jest.spyOn(injectedAuthService, 'logout')
+        jest.spyOn(injectedAuthService, 'login')
 
         http.get('/data').subscribe()
 
         httpMock.expectOne('/data').flush(data, mockErrorResponse)
-        expect(injectedAuthService.logout).toHaveBeenCalled()
+        expect(injectedAuthService.login).toHaveBeenCalled()
       }
     ))
   })

--- a/src/app/core/interceptors/error.interceptor.ts
+++ b/src/app/core/interceptors/error.interceptor.ts
@@ -16,7 +16,7 @@ export class ErrorInterceptor implements HttpInterceptor {
     return next.handle(request).pipe(
       catchError((err) => {
         if (err.status === 401) {
-          this.authService.logout()
+          this.authService.login(window.location.href)
         }
         if (err.status === 403) {
           this.profileService.setUnapproveUser(true)

--- a/src/app/core/interceptors/oauth.interceptor.spec.ts
+++ b/src/app/core/interceptors/oauth.interceptor.spec.ts
@@ -12,7 +12,7 @@ describe('OAuthInterceptor', () => {
   } as OAuthStorage
 
   const authService = {
-    logOut: () => {},
+    initCodeFlow: () => {},
   } as OAuthService
 
   beforeEach(() => {
@@ -75,12 +75,12 @@ describe('OAuthInterceptor', () => {
         const mockErrorResponse = { status: 401, statusText: 'Unauthorized' }
         const data = 'Unauthorized'
 
-        jest.spyOn(injectedAuthService, 'logOut')
+        jest.spyOn(injectedAuthService, 'initCodeFlow')
 
         http.get('/data').subscribe()
 
         httpMock.expectOne('/data').flush(data, mockErrorResponse)
-        expect(injectedAuthService.logOut).toHaveBeenCalled()
+        expect(injectedAuthService.initCodeFlow).toHaveBeenCalled()
       }
     ))
   })
@@ -92,12 +92,12 @@ describe('OAuthInterceptor', () => {
         const mockErrorResponse = { status: 500, statusText: 'Internal Server Error' }
         const data = 'Internal Server Error'
 
-        jest.spyOn(injectedAuthService, 'logOut')
+        jest.spyOn(injectedAuthService, 'initCodeFlow')
 
         http.get('/data').subscribe()
 
         httpMock.expectOne('/data').flush(data, mockErrorResponse)
-        expect(injectedAuthService.logOut).not.toHaveBeenCalled()
+        expect(injectedAuthService.initCodeFlow).not.toHaveBeenCalled()
       }
     ))
   })

--- a/src/app/core/interceptors/oauth.interceptor.ts
+++ b/src/app/core/interceptors/oauth.interceptor.ts
@@ -35,7 +35,7 @@ export class OAuthInterceptor implements HttpInterceptor {
 
   private handleError(error: HttpErrorResponse): Observable<never> {
     if (error.status === 401) {
-      this.oauthService.logOut()
+      this.oauthService.initCodeFlow(window.location.href)
     } else if (error.status === 409 && error.url.includes('/admin/user/')) {
       return of()
     }


### PR DESCRIPTION
After automatic logout, a non-helpful error message is shown to the users

#### Environment
num-portal-webapp 1.18, Keycloak 24

#### Steps to Reproduce
 - Login in RDP
 - Wait for session timeout (Can be lowered in KC: Realm settings > Sessions > SSO Session Idle)
 - Click  in the sidebar to open a new page

#### Actual Result
 - You are redirected to KC logout page
 - The following error is shown:
![Screenshot](https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/assets/7806499/08fbebb3-9518-4350-86dd-77c497de42cd)

#### Expected Result
I would expect to be redirected to the login page instead, so that I can login again
