### PR TITLE
Use correct class type for FROM clause on criteria page

### DIFF
--- a/src/app/shared/models/aqb/aqb-contains-item-ui.model.ts
+++ b/src/app/shared/models/aqb/aqb-contains-item-ui.model.ts
@@ -2,6 +2,8 @@ import { IAqbContainmentNode } from 'src/app/shared/models/archetype-query-build
 import { AqbNodeType } from 'src/app/shared/models/archetype-query-builder/builder-request/aqb-node-type.enum'
 import { ConnectorNodeType } from 'src/app/shared/models/connector-node-type.enum'
 
+const archetypeToClassType = /openEHR-EHR-([A-Z]*)\..*/
+
 export class AqbContainsItemUiModel {
   readonly type = ConnectorNodeType.Aqb_Item
   compositionId: string
@@ -21,9 +23,10 @@ export class AqbContainsItemUiModel {
   }
 
   convertToApi(): IAqbContainmentNode {
+    const match = this.archetypeId.match(archetypeToClassType)
     return {
       _type: AqbNodeType.Containment,
-      type: 'OBSERVATION',
+      type: match[1],
       identifier: `o${this.archetypeReferenceId}`,
       predicates: `[${this.archetypeId}]`,
     }


### PR DESCRIPTION
When creating a criterion on the criteria builder page, the resulting AQL FROM clause always used the class type OBSERVATION. In this commit it is changed to use a class type depending on the archetype name.