### PR TITLE
Do not initialise Idle twice

### DIFF
--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -118,7 +118,7 @@ export class AuthService {
         .toPromise()
         .finally(() => {
           if (!this.idle.isIdling()) {
-            this.initIdle()
+            this.resetIdle()
           }
         })
     }


### PR DESCRIPTION
When reloading the page, initIdle() is called twice, which causes two onTimeout subscription. This causes problems when loading the KC logout page, because the id_token_hint parameter isn't passed.

![Bildschirmfoto vom 2024-06-20 14-36-54](https://github.com/NUM-Forschungsdatenplattform/num-portal-webapp/assets/7806499/26936bb0-eb6f-4389-ae30-40db352c3459)
