### PR TITLE
Use String as default type

### DIFF
--- a/src/app/shared/models/aqb/aqb-where-item-ui.model.ts
+++ b/src/app/shared/models/aqb/aqb-where-item-ui.model.ts
@@ -75,11 +75,8 @@ export class AqbWhereItemUiModel {
         return 'Double'
       case ReferenceModelType.Long:
         return 'Long'
-      case ReferenceModelType.String:
-      case ReferenceModelType.Code_phrase:
-        return 'String'
       default:
-        return rmType
+        return 'String'
     }
   }
 


### PR DESCRIPTION
When using the criteria builder, adding a parameter with a non-primitive data type to 'Where' and clicking 'Apply selection', the following exception occurs. Examples: Alter, Sterbedatum, Composer, Postfach in GECCO_Personendaten It seems that most non-primitive type are passed as strings, therefore I would use that as a default.

```
JSON parse error: Could not resolve type id 'TEMPORAL_AMOUNT' as a subtype of `org.ehrbase.openehr.sdk.aql.dto.operand.Operand`: known type ids = [Boolean, Double, IdentifiedPath, Long, Null, QueryParameter, SingleRowFunction, String, Temporal, TerminologyFunction] (for POJO property 'value')

org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error: Could not resolve type id 'TEMPORAL_AMOUNT' as a subtype of `org.ehrbase.openehr.sdk.aql.dto.operand.Operand`: known type ids = [Boolean, Double, IdentifiedPath, Long, Null, QueryParameter, SingleRowFunction, String, Temporal, TerminologyFunction] (for POJO property 'value')
```