### PR TITLE
Don't try to change enabled status of current user

### DIFF
--- a/src/app/modules/user-management/components/dialog-edit-user-details/dialog-edit-user-details.component.spec.ts
+++ b/src/app/modules/user-management/components/dialog-edit-user-details/dialog-edit-user-details.component.spec.ts
@@ -20,7 +20,7 @@ import { IToastMessageConfig } from 'src/app/shared/models/toast-message-config.
 import { IUserProfile } from 'src/app/shared/models/user/user-profile.interface'
 import { mockUser } from 'src/mocks/data-mocks/admin.mock'
 import { mockOrganization2, mockOrganizations } from 'src/mocks/data-mocks/organizations.mock'
-import { mockUserProfile1 } from 'src/mocks/data-mocks/user-profile.mock'
+import { mockUserProfile1, mockUserProfile2 } from 'src/mocks/data-mocks/user-profile.mock'
 import { AddUserOrganizationComponent } from '../add-user-organization/add-user-organization.component'
 import { AddUserRolesComponent } from '../add-user-roles/add-user-roles.component'
 import { EDIT_USER_ERROR, EDIT_USER_SUCCESS, INVALID_USER_NAME_ERROR } from './constants'
@@ -52,6 +52,7 @@ describe('DialogEditUserDetailsComponent', () => {
 
   const userProfileSubject$ = new Subject<IUserProfile>()
   const profileService = {
+    get: jest.fn(),
     userProfileObservable$: userProfileSubject$.asObservable(),
   } as unknown as ProfileService
 
@@ -118,6 +119,7 @@ describe('DialogEditUserDetailsComponent', () => {
     jest.spyOn(adminService, 'approveUser').mockImplementation((userId: string) => of(userId))
     jest.spyOn(adminService, 'refreshFilterResult').mockImplementation(() => of())
     jest.spyOn(adminService, 'getUnapprovedUsers').mockImplementation(() => of([]))
+    jest.spyOn(profileService, 'get').mockImplementation(() => of(mockUserProfile2))
   })
 
   afterEach(() => {
@@ -308,7 +310,7 @@ describe('DialogEditUserDetailsComponent', () => {
       expect(component.userNameForm.get('lastName').value).toEqual(mockUser.lastName)
     })
 
-    it('should not call changeUnserName method of admin service on uncahched data', async () => {
+    it('should not call changeUserName method of admin service on uncached data', async () => {
       jest.spyOn(adminService, 'changeUserName')
       await component.handleDialogConfirm()
       expect(adminService.changeUserName).not.toHaveBeenCalled()

--- a/src/app/modules/user-management/components/dialog-edit-user-details/dialog-edit-user-details.component.ts
+++ b/src/app/modules/user-management/components/dialog-edit-user-details/dialog-edit-user-details.component.ts
@@ -151,11 +151,22 @@ export class DialogEditUserDetailsComponent
   }
 
   async closeDialogAndRefreshUsers(): Promise<void> {
-    this.adminService.changeUserEnabledStatus(this.userDetails.id, this.isActive).subscribe(() => {
-      this.adminService.refreshFilterResult()
+    this.isSelectedEqualToCurrent.then((dontChangeEnabledStatus) => {
+      if (dontChangeEnabledStatus) {
+        this.adminService.refreshFilterResult()
 
-      this.closeDialog.emit()
-      return Promise.resolve()
+        this.closeDialog.emit()
+        return Promise.resolve()
+      } else {
+        this.adminService
+          .changeUserEnabledStatus(this.userDetails.id, this.isActive)
+          .subscribe(() => {
+            this.adminService.refreshFilterResult()
+
+            this.closeDialog.emit()
+            return Promise.resolve()
+          })
+      }
     })
   }
 


### PR DESCRIPTION
The currently logged-in user can't change their own enabled status, however on clicking Save in the user edit dialog the changeUserEnabledStatus method is still called. Because of this, on server side a ForbiddenException is thrown and the dialog window does not close. With this commit a check is added not to call the method.