### PR TITLE
Use AND operator for multiple compositions

### DIFF
--- a/src/app/shared/models/aqb/aqb-contains-ui.model.ts
+++ b/src/app/shared/models/aqb/aqb-contains-ui.model.ts
@@ -44,7 +44,7 @@ export class AqbContainsUiModel {
       if (compositions.length > 1) {
         const contains: IAqbLogicalOperatorNode<PossibleContains> = {
           _type: AqbNodeType.LogicalOperator,
-          symbol: LogicalOperator.Or,
+          symbol: LogicalOperator.And,
           values: compositions.map((composition) => composition.convertToApi()),
         }
         return contains

--- a/src/app/shared/models/aqb/aqb-where-group-ui.model.ts
+++ b/src/app/shared/models/aqb/aqb-where-group-ui.model.ts
@@ -17,7 +17,7 @@ export class AqbWhereGroupUiModel {
   constructor(baseGroup = false) {
     if (baseGroup) {
       const templateRestrictionGroup = new AqbWhereGroupUiModel()
-      templateRestrictionGroup.logicalOperator = LogicalOperator.Or
+      templateRestrictionGroup.logicalOperator = LogicalOperator.And
       this.children.push(templateRestrictionGroup)
       this.children.push(new AqbWhereGroupUiModel())
     }


### PR DESCRIPTION
When a user selects elements from multiple templates in the query builder, the composition are combined with OR currently. 
It makes more sense that all composition are combined with AND, so that they are all available in the result. If required, it is possible to use OR in the WHERE part.

For example, when selecting elements from Blutdruck and Patientenaufenthalt (FROM and WHERE part):
Before:
```
FROM
  EHR e
  CONTAINS ((COMPOSITION c1[openEHR-EHR-COMPOSITION.registereintrag.v1]
  CONTAINS OBSERVATION o2[openEHR-EHR-OBSERVATION.blood_pressure.v2])
  OR (COMPOSITION c3[openEHR-EHR-COMPOSITION.event_summary.v0]
  CONTAINS CLUSTER o4[openEHR-EHR-CLUSTER.case_identification.v0]))
WHERE
  (c1/archetype_details/template_id/value = 'Blutdruck'
  OR c3/archetype_details/template_id/value = 'Patientenaufenthalt')
```
After:
```
FROM
  EHR e
  CONTAINS ((COMPOSITION c1[openEHR-EHR-COMPOSITION.registereintrag.v1]
  CONTAINS OBSERVATION o2[openEHR-EHR-OBSERVATION.blood_pressure.v2])
  AND (COMPOSITION c3[openEHR-EHR-COMPOSITION.event_summary.v0]
  CONTAINS CLUSTER o4[openEHR-EHR-CLUSTER.case_identification.v0]))
WHERE
  (c1/archetype_details/template_id/value = 'Blutdruck'
  AND c3/archetype_details/template_id/value = 'Patientenaufenthalt')
```