### PR TITLE
Use both archetype and template name for reference key

### DIFF
--- a/src/app/shared/models/aqb/aqb-ui.model.ts
+++ b/src/app/shared/models/aqb/aqb-ui.model.ts
@@ -29,9 +29,10 @@ export class AqbUiModel {
     const archetypeId = clickEvent.item.archetypeId || clickEvent.item.parentArchetypeId
     const compositionReferenceKey = clickEvent.compositionId
     const archetypeReferenceKey = archetypeId
+    const templateId = clickEvent.templateId
 
     const compositionReferenceId = this.setReference(compositionReferenceKey)
-    const archetypeReferenceId = this.setReference(archetypeReferenceKey)
+    const archetypeReferenceId = this.setReference(archetypeReferenceKey + templateId)
 
     if (!this.usedTemplates.includes(clickEvent.templateId)) {
       this.usedTemplates.push(clickEvent.templateId)


### PR DESCRIPTION
When the same archetype appears in multiple compositions in the query builder, its ID is reused. But each instance of the archetype must have a unique ID, otherwise this exception occurs:
```
o.h.aqleditor.controller.BaseController  : JSON parse error: Already had POJO for id (java.lang.String) [[ObjectId: key=o2, type=com.fasterxml.jackson.databind.deser.impl.PropertyBasedObjectIdGenerator, scope=java.lang.Object]]

```

Example: Select `Fall-Kennung` from `Diagnose`, and `Zugehöriger Versorgungsfall (Kennung)` from `Patientenaufenthalt`