### PR TITLE
Query Builder: after deleting and re-adding the COMPOSITION, the template ID isn't re-inserted

### DIFF
--- a/src/app/modules/aqls/components/aql-builder-contains-group/aql-builder-contains-group.component.html
+++ b/src/app/modules/aqls/components/aql-builder-contains-group/aql-builder-contains-group.component.html
@@ -38,7 +38,6 @@
     [parentGroupIndex]="groupIndex"
     [index]="i"
     (delete)="deleteChildGroup($event)"
-    (deleteArchetypesByReferenceIds)="this.deleteArchetypes.emit($event)"
     data-test="aqb__contains__group"
   ></num-aql-builder-contains-group>
 

--- a/src/app/shared/models/aqb/aqb-ui.model.ts
+++ b/src/app/shared/models/aqb/aqb-ui.model.ts
@@ -13,6 +13,8 @@ export class AqbUiModel {
   private referenceCounter = 0
   private references = new Map<string, number>()
   private usedTemplates: string[] = []
+  private compositionReferenceIdTemplateId = new Map<number, string>()
+  private archetypeReferenceIdTemplateId = new Map<number, string>()
 
   selectDestination = AqbSelectDestination.Select
 
@@ -33,6 +35,9 @@ export class AqbUiModel {
 
     const compositionReferenceId = this.setReference(compositionReferenceKey + templateId)
     const archetypeReferenceId = this.setReference(archetypeReferenceKey + templateId)
+
+    this.compositionReferenceIdTemplateId.set(compositionReferenceId, templateId)
+    this.archetypeReferenceIdTemplateId.set(archetypeReferenceId, templateId)
 
     if (!this.usedTemplates.includes(clickEvent.templateId)) {
       this.usedTemplates.push(clickEvent.templateId)
@@ -150,6 +155,11 @@ export class AqbUiModel {
       (item) => !compositionReferenceIds.includes(item.compositionReferenceId)
     )
 
+    const toDelete = compositionReferenceIds.map((item) =>
+      this.compositionReferenceIdTemplateId.get(item)
+    )
+    this.usedTemplates = this.usedTemplates.filter((item) => !toDelete.includes(item))
+
     const templateRestrictionWhereClause = this.where.children[0] as AqbWhereGroupUiModel
     const userGeneratedWhereClause = this.where.children[1] as AqbWhereGroupUiModel
 
@@ -163,6 +173,11 @@ export class AqbUiModel {
 
   handleDeletionByArchetypeReferenceIds(archetypeReferenceIds: number[]): void {
     this.deleteReferencesByIds(archetypeReferenceIds)
+
+    const toDelete = archetypeReferenceIds.map((item) =>
+      this.archetypeReferenceIdTemplateId.get(item)
+    )
+    this.usedTemplates = this.usedTemplates.filter((item) => !toDelete.includes(item))
 
     this.select = this.select.filter(
       (item) => !archetypeReferenceIds.includes(item.archetypeReferenceId)


### PR DESCRIPTION
Steps to reproduce:
 - Go to Criteria Editor page
 - Open the query builder
 - Add an arbitrary element to SELECT → A composition is automatically added to  FROM
 - Click Apply Selection → The resulting AQL code contains `WHERE   c1/archetype_details/template_id/value = '<template name>'`
 - Open the query builder again
 - Delete the composition → The SELECT part is deleted automatically 
 - Add the same arbitrary element to SELECT again → The composition is automatically re-added 
 - Click Apply Selection → The resulting AQL does not contain the  template_id part