### PR TITLE
fix category editor not accessible

### DIFF
--- a/src/app/modules/aqls/aqls-routing.module.ts
+++ b/src/app/modules/aqls/aqls-routing.module.ts
@@ -17,7 +17,7 @@ const routes: Routes = [
   },
   {
     path: 'categories',
-    canLoad: [RoleGuard],
+    canMatch: [RoleGuard],
     data: {
       tabNavId: 'aql-categories',
       roles: [AvailableRoles.Manager],


### PR DESCRIPTION
The category editor is not accessible because the `canLoad` evaluation does not work.

I propose to change this to `canMatch` as in the  rest of the codebase. This leads to the following behavior:

Users with the role `MANAGER`: Can see the menu entry and access it.
Users without the role `MANAGER`: Can't see the menu entry and cannot access it.